### PR TITLE
Project refactoring

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:usesCleartextTraffic="true"
         android:theme="@style/Theme.FantasyPremierLeague">
         <activity
-            android:name=".ui.MainActivity"
+            android:name=".MainActivity"
             android:theme="@style/Theme.FantasyPremierLeague.NoActionBar"
             android:label="@string/app_name">
             <intent-filter>

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -2,31 +2,15 @@ package dev.johnoreilly.fantasypremierleague
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.*
-import androidx.compose.material.MaterialTheme.typography
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.setContent
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
-import dev.chrisbanes.accompanist.coil.CoilImage
-import dev.johnoreilly.common.repository.Player
-import dev.johnoreilly.fantasypremierleague.ui.FantasyPremierLeagueTheme
-import dev.johnoreilly.fantasypremierleague.ui.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.global.FantasyPremierLeagueTheme
+import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.fixtures.FixturesListView
+import dev.johnoreilly.fantasypremierleague.ui.players.playerDetails.PlayerDetailsView
+import dev.johnoreilly.fantasypremierleague.ui.players.PlayerListView
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 
@@ -76,164 +60,8 @@ fun MainLayout(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
                 )
             }
             composable(Screen.FixtureListScreen.title) {
-                FixtureList(fantasyPremierLeagueViewModel = fantasyPremierLeagueViewModel)
+                FixturesListView(fantasyPremierLeagueViewModel = fantasyPremierLeagueViewModel)
             }
         }
     }
-}
-
-@Composable
-fun PlayerListView(
-    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel,
-    onPlayerSelected: (playerId: Int) -> Unit
-) {
-    val playerList = fantasyPremierLeagueViewModel.players.observeAsState()
-    val playerSearchQuery = fantasyPremierLeagueViewModel.query
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = {
-                    Text("Fantasy Premier League")
-                }
-            )
-        },
-        bodyContent = {
-            Column {
-                TextField(
-                    singleLine = true,
-                    value = playerSearchQuery.value,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp),
-                    label = {
-                        Text(text = "Search")
-                    },
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Default.Search,
-                            contentDescription = "Search"
-                        )
-                    },
-                    keyboardOptions = KeyboardOptions(
-                        keyboardType = KeyboardType.Text,
-                        imeAction = ImeAction.Search
-                    ),
-                    onImeActionPerformed = { action, softKeyboardController ->
-                        if (action == ImeAction.Search) {
-                            fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(
-                                playerSearchQuery.value
-                            )
-                            softKeyboardController?.hideSoftwareKeyboard()
-                        }
-                    },
-                    onValueChange = {
-                        playerSearchQuery.value = it
-                        fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(it)
-                    }
-                )
-
-                playerList.value?.let {
-                    LazyColumn {
-                        items(items = it, itemContent = { player ->
-                            PlayerView(player, onPlayerSelected)
-                        })
-                    }
-                }
-            }
-        }
-    )
-}
-
-@Composable
-fun PlayerView(
-    player: Player,
-    onPlayerSelected: (playerId: Int) -> Unit
-) {
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        modifier = Modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-            .clickable { onPlayerSelected(player.id) }
-    ) {
-        CoilImage(
-            data = player.photoUrl,
-            modifier = Modifier.preferredSize(60.dp),
-            contentDescription = player.name
-        )
-        Spacer(modifier = Modifier.preferredSize(12.dp))
-        Column(
-            modifier = Modifier
-                .weight(1f)
-                .padding(start = 8.dp)
-        ) {
-            Text(player.name, style = typography.h6)
-            Text(player.team, style = typography.subtitle1, color = Color.DarkGray)
-        }
-        Text(player.points.toString(), style = typography.h6)
-    }
-}
-
-@Composable
-fun PlayerDetailsView(
-    player: Player,
-    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel
-) {
-    Column(
-        modifier = Modifier
-            .padding(16.dp)
-            .fillMaxWidth()
-    ) {
-        Row(
-            modifier = Modifier
-                .preferredHeight(150.dp)
-                .fillMaxWidth()
-        ) {
-            CoilImage(
-                data = player.photoUrl,
-                modifier = Modifier.preferredSize(150.dp),
-                contentDescription = player.name
-            )
-            Column(
-                verticalArrangement = Arrangement.Center,
-                modifier = Modifier
-                    .preferredHeight(100.dp)
-                    .fillMaxWidth()
-            ) {
-                Text(player.name, style = typography.h6)
-                Text(player.team, style = typography.subtitle1, color = Color.DarkGray)
-            }
-        }
-        Spacer(modifier = Modifier.size(16.dp))
-        Row {
-            Text(text = "POINTS:", style = typography.subtitle1)
-            Text(
-                player.points.toString(),
-                modifier = Modifier.align(Alignment.CenterVertically),
-                style = typography.subtitle1,
-                fontWeight = FontWeight.Bold
-            )
-        }
-    }
-}
-
-@Composable
-fun FixtureList(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
-    val fixtureListState = fantasyPremierLeagueViewModel.fixtures.observeAsState(emptyList())
-
-    Scaffold(
-        topBar = {
-            TopAppBar(title = { Text("Fantasy Premier League") })
-        },
-        bodyContent = {
-            Column {
-                LazyColumn {
-                    items(items = fixtureListState.value, itemContent = { fixture ->
-                        Text(fixture.kickoff_time ?: "")
-                    })
-                }
-            }
-        }
-    )
 }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.platform.setContent
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import dev.johnoreilly.fantasypremierleague.ui.global.FantasyPremierLeagueTheme
-import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 import dev.johnoreilly.fantasypremierleague.ui.fixtures.FixturesListView
 import dev.johnoreilly.fantasypremierleague.ui.players.playerDetails.PlayerDetailsView
 import dev.johnoreilly.fantasypremierleague.ui.players.PlayerListView
@@ -15,13 +15,13 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 
 class MainActivity : AppCompatActivity() {
-    private val fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel by viewModel()
+    private val playersViewModel: PlayersViewModel by viewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         setContent {
-            MainLayout(fantasyPremierLeagueViewModel)
+            MainLayout(playersViewModel)
         }
     }
 }
@@ -33,14 +33,14 @@ sealed class Screen(val title: String) {
 }
 
 @Composable
-fun MainLayout(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
+fun MainLayout(playersViewModel: PlayersViewModel) {
     val navController = rememberNavController()
 
     FantasyPremierLeagueTheme {
         NavHost(navController, startDestination = Screen.PlayerListScreen.title) {
             composable(Screen.PlayerListScreen.title) {
                 PlayerListView(
-                    fantasyPremierLeagueViewModel = fantasyPremierLeagueViewModel,
+                    playersViewModel = playersViewModel,
                     onPlayerSelected = { playerId ->
                         navController.navigate(Screen.PlayerDetailsScreen.title + "/${playerId}")
                     }
@@ -51,16 +51,16 @@ fun MainLayout(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
                 arguments = listOf(navArgument("playerId") { type = NavType.IntType })
             ) { navBackStackEntry ->
                 val playerId: Int? = navBackStackEntry.arguments?.getInt("playerId")
-                val player = fantasyPremierLeagueViewModel.players.value?.first { it.id == playerId }
+                val player = playersViewModel.players.value?.first { it.id == playerId }
 
                 // TODO error handling for invalid playerId edge case or when first throws an exception
                 PlayerDetailsView(
                     player = player!!,
-                    fantasyPremierLeagueViewModel = fantasyPremierLeagueViewModel
+                    playersViewModel = playersViewModel
                 )
             }
             composable(Screen.FixtureListScreen.title) {
-                FixturesListView(fantasyPremierLeagueViewModel = fantasyPremierLeagueViewModel)
+                FixturesListView(playersViewModel = playersViewModel)
             }
         }
     }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -1,4 +1,4 @@
-package dev.johnoreilly.fantasypremierleague.ui
+package dev.johnoreilly.fantasypremierleague
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -25,6 +25,8 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import dev.chrisbanes.accompanist.coil.CoilImage
 import dev.johnoreilly.common.repository.Player
+import dev.johnoreilly.fantasypremierleague.ui.FantasyPremierLeagueTheme
+import dev.johnoreilly.fantasypremierleague.ui.FantasyPremierLeagueViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.setContent
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
+import dev.johnoreilly.fantasypremierleague.ui.Screen
 import dev.johnoreilly.fantasypremierleague.ui.global.FantasyPremierLeagueTheme
 import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 import dev.johnoreilly.fantasypremierleague.ui.fixtures.FixturesListView
@@ -24,12 +25,6 @@ class MainActivity : AppCompatActivity() {
             MainLayout(playersViewModel)
         }
     }
-}
-
-sealed class Screen(val title: String) {
-    object PlayerListScreen : Screen("PlayerListScreen")
-    object PlayerDetailsScreen : Screen("PlayerDetailsScreen")
-    object FixtureListScreen : Screen("FixtureListScreen")
 }
 
 @Composable

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/di/AppModule.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/di/AppModule.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.fantasypremierleague.di
 
-import dev.johnoreilly.fantasypremierleague.ui.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/di/AppModule.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/di/AppModule.kt
@@ -1,9 +1,9 @@
 package dev.johnoreilly.fantasypremierleague.di
 
-import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val appModule = module {
-    viewModel { FantasyPremierLeagueViewModel(get(),get()) }
+    viewModel { PlayersViewModel(get(),get()) }
 }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/Screen.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/Screen.kt
@@ -1,0 +1,7 @@
+package dev.johnoreilly.fantasypremierleague.ui
+
+sealed class Screen(val title: String) {
+    object PlayerListScreen : Screen("PlayerListScreen")
+    object PlayerDetailsScreen : Screen("PlayerDetailsScreen")
+    object FixtureListScreen : Screen("FixtureListScreen")
+}

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/fixtures/FixturesListView.kt
@@ -1,0 +1,31 @@
+package dev.johnoreilly.fantasypremierleague.ui.fixtures
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+
+@Composable
+fun FixturesListView(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
+    val fixtureListState = fantasyPremierLeagueViewModel.fixtures.observeAsState(emptyList())
+
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text("Fantasy Premier League") })
+        },
+        bodyContent = {
+            Column {
+                LazyColumn {
+                    items(items = fixtureListState.value, itemContent = { fixture ->
+                        Text(fixture.kickoff_time ?: "")
+                    })
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/fixtures/FixturesListView.kt
@@ -8,11 +8,11 @@ import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.livedata.observeAsState
-import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 
 @Composable
-fun FixturesListView(fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel) {
-    val fixtureListState = fantasyPremierLeagueViewModel.fixtures.observeAsState(emptyList())
+fun FixturesListView(playersViewModel: PlayersViewModel) {
+    val fixtureListState = playersViewModel.fixtures.observeAsState(emptyList())
 
     Scaffold(
         topBar = {

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Color.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Color.kt
@@ -1,4 +1,4 @@
-package dev.johnoreilly.fantasypremierleague.ui
+package dev.johnoreilly.fantasypremierleague.ui.global
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Color.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Color.kt
@@ -7,7 +7,7 @@ val maroon200 = Color(0xFFb73d2a)
 val maroon500 = Color(0xFF800000)
 val maroon700 = Color(0xFF4f0000)
 val teal200 = Color(0xFF03DAC5)
-
-
-val lowAvailabilityColor = Color(0xFFFF8C00)
-val highAvailabilityColor = Color(0xFF008000)
+val teal700 = Color(0xFF00bfa5)
+val white = Color(0xFFFFFFFF)
+val black = Color(0xFF000000)
+val red = Color(0xFFd50000)

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Theme.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Theme.kt
@@ -1,4 +1,4 @@
-package dev.johnoreilly.fantasypremierleague.ui
+package dev.johnoreilly.fantasypremierleague.ui.global
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
@@ -21,11 +21,8 @@ private val LightColorPalette = lightColors(
 
 @Composable
 fun FantasyPremierLeagueTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
-    val colors = if (darkTheme) {
-        DarkColorPalette
-    } else {
-        LightColorPalette
-    }
+    val colors = if (darkTheme) DarkColorPalette
+    else LightColorPalette
 
     MaterialTheme(
         colors = colors,

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Theme.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/global/Theme.kt
@@ -8,24 +8,40 @@ import androidx.compose.runtime.Composable
 
 
 private val DarkColorPalette = darkColors(
-        primary = maroon200,
-        primaryVariant = maroon700,
-        secondary = teal200
+    primary = maroon200,
+    primaryVariant = maroon700,
+    secondary = teal200,
+    background = black,
+    surface = black,
+    error = red,
+    onPrimary = white,
+    onSecondary = black,
+    onBackground = white,
+    onSurface = white,
+    onError = white
 )
 
 private val LightColorPalette = lightColors(
-        primary = maroon500,
-        primaryVariant = maroon700,
-        secondary = teal200
+    primary = maroon500,
+    primaryVariant = maroon700,
+    secondary = teal200,
+    secondaryVariant = teal700,
+    background = white,
+    surface = white,
+    error = red,
+    onPrimary = white,
+    onSecondary = black,
+    onBackground = black,
+    onSurface = black,
+    onError = white
 )
 
 @Composable
-fun FantasyPremierLeagueTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable() () -> Unit) {
-    val colors = if (darkTheme) DarkColorPalette
-    else LightColorPalette
+fun FantasyPremierLeagueTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable() () -> Unit
+) {
+    val colors = if (darkTheme) DarkColorPalette else LightColorPalette
 
-    MaterialTheme(
-        colors = colors,
-        content = content
-    )
+    MaterialTheme(colors = colors, content = content)
 }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/FantasyPremierLeagueViewModel.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/FantasyPremierLeagueViewModel.kt
@@ -1,4 +1,4 @@
-package dev.johnoreilly.fantasypremierleague.ui
+package dev.johnoreilly.fantasypremierleague.ui.players
 
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.*

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayerView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayerView.kt
@@ -1,0 +1,43 @@
+package dev.johnoreilly.fantasypremierleague.ui.players
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.accompanist.coil.CoilImage
+import dev.johnoreilly.common.repository.Player
+
+@Composable
+fun PlayerView(
+    player: Player,
+    onPlayerSelected: (playerId: Int) -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+            .clickable { onPlayerSelected(player.id) }
+    ) {
+        CoilImage(
+            data = player.photoUrl,
+            modifier = Modifier.preferredSize(60.dp),
+            contentDescription = player.name
+        )
+        Spacer(modifier = Modifier.preferredSize(12.dp))
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .padding(start = 8.dp)
+        ) {
+            Text(player.name, style = MaterialTheme.typography.h6)
+            Text(player.team, style = MaterialTheme.typography.subtitle1, color = Color.DarkGray)
+        }
+        Text(player.points.toString(), style = MaterialTheme.typography.h6)
+    }
+}

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
@@ -18,11 +18,11 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun PlayerListView(
-    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel,
+    playersViewModel: PlayersViewModel,
     onPlayerSelected: (playerId: Int) -> Unit
 ) {
-    val playerList = fantasyPremierLeagueViewModel.players.observeAsState()
-    val playerSearchQuery = fantasyPremierLeagueViewModel.query
+    val playerList = playersViewModel.players.observeAsState()
+    val playerSearchQuery = playersViewModel.query
 
     Scaffold(
         topBar = {
@@ -55,7 +55,7 @@ fun PlayerListView(
                     ),
                     onImeActionPerformed = { action, softKeyboardController ->
                         if (action == ImeAction.Search) {
-                            fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(
+                            playersViewModel.onPlayerSearchQueryChange(
                                 playerSearchQuery.value
                             )
                             softKeyboardController?.hideSoftwareKeyboard()
@@ -63,7 +63,7 @@ fun PlayerListView(
                     },
                     onValueChange = {
                         playerSearchQuery.value = it
-                        fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(it)
+                        playersViewModel.onPlayerSearchQueryChange(it)
                     }
                 )
 

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
@@ -34,7 +34,7 @@ fun PlayerListView(
         },
         bodyContent = {
             Column {
-                TextField(
+                OutlinedTextField(
                     singleLine = true,
                     value = playerSearchQuery.value,
                     modifier = Modifier

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
@@ -1,0 +1,80 @@
+package dev.johnoreilly.fantasypremierleague.ui.players
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun PlayerListView(
+    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel,
+    onPlayerSelected: (playerId: Int) -> Unit
+) {
+    val playerList = fantasyPremierLeagueViewModel.players.observeAsState()
+    val playerSearchQuery = fantasyPremierLeagueViewModel.query
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text("Fantasy Premier League")
+                }
+            )
+        },
+        bodyContent = {
+            Column {
+                TextField(
+                    singleLine = true,
+                    value = playerSearchQuery.value,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                    label = {
+                        Text(text = "Search")
+                    },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = Icons.Default.Search,
+                            contentDescription = "Search"
+                        )
+                    },
+                    keyboardOptions = KeyboardOptions(
+                        keyboardType = KeyboardType.Text,
+                        imeAction = ImeAction.Search
+                    ),
+                    onImeActionPerformed = { action, softKeyboardController ->
+                        if (action == ImeAction.Search) {
+                            fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(
+                                playerSearchQuery.value
+                            )
+                            softKeyboardController?.hideSoftwareKeyboard()
+                        }
+                    },
+                    onValueChange = {
+                        playerSearchQuery.value = it
+                        fantasyPremierLeagueViewModel.onPlayerSearchQueryChange(it)
+                    }
+                )
+
+                playerList.value?.let {
+                    LazyColumn {
+                        items(items = it, itemContent = { player ->
+                            PlayerView(player, onPlayerSelected)
+                        })
+                    }
+                }
+            }
+        }
+    )
+}

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersViewModel.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersViewModel.kt
@@ -10,7 +10,7 @@ import dev.johnoreilly.common.repository.Player
 import kotlinx.coroutines.launch
 
 
-class FantasyPremierLeagueViewModel(
+class PlayersViewModel(
     private val repository: FantasyPremierLeagueRepository,
     private val logger: Kermit
 ) : ViewModel() {

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/playerDetails/PlayerDetailsView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/playerDetails/PlayerDetailsView.kt
@@ -11,12 +11,12 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import dev.chrisbanes.accompanist.coil.CoilImage
 import dev.johnoreilly.common.repository.Player
-import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 
 @Composable
 fun PlayerDetailsView(
     player: Player,
-    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel
+    playersViewModel: PlayersViewModel
 ) {
     Column(
         modifier = Modifier

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/playerDetails/PlayerDetailsView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/playerDetails/PlayerDetailsView.kt
@@ -1,0 +1,57 @@
+package dev.johnoreilly.fantasypremierleague.ui.players.playerDetails
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import dev.chrisbanes.accompanist.coil.CoilImage
+import dev.johnoreilly.common.repository.Player
+import dev.johnoreilly.fantasypremierleague.ui.players.FantasyPremierLeagueViewModel
+
+@Composable
+fun PlayerDetailsView(
+    player: Player,
+    fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel
+) {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)
+            .fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .preferredHeight(150.dp)
+                .fillMaxWidth()
+        ) {
+            CoilImage(
+                data = player.photoUrl,
+                modifier = Modifier.preferredSize(150.dp),
+                contentDescription = player.name
+            )
+            Column(
+                verticalArrangement = Arrangement.Center,
+                modifier = Modifier
+                    .preferredHeight(100.dp)
+                    .fillMaxWidth()
+            ) {
+                Text(player.name, style = MaterialTheme.typography.h6)
+                Text(player.team, style = MaterialTheme.typography.subtitle1, color = Color.DarkGray)
+            }
+        }
+        Spacer(modifier = Modifier.size(16.dp))
+        Row {
+            Text(text = "POINTS:", style = MaterialTheme.typography.subtitle1)
+            Text(
+                player.points.toString(),
+                modifier = Modifier.align(Alignment.CenterVertically),
+                style = MaterialTheme.typography.subtitle1,
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}


### PR DESCRIPTION
### Changes

* Propagate `MainActivity` to `Application` class level as `single-activity` architecture will be followed.
* `Composables` have been moved from `Activity` class to their respective `feature` directories.
* `FantasyPremierLeagueViewModel` renamed to `PlayersViewModel`, given its scope and usage.
* Setup material design compliant color palette.

### Future changes

* Configure `PlayerDetailsView` to be iOS mockup compliant.
* Add support for `BottomNavigation` through `Scaffold` for the following primary destinations:
  * Players
  * Fixtures