### PR TITLE
Setup bottom navigation bar globally

### DIFF
--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -2,11 +2,20 @@ package dev.johnoreilly.fantasypremierleague
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.setContent
 import androidx.navigation.NavType
 import androidx.navigation.compose.*
 import dev.johnoreilly.fantasypremierleague.ui.Screen
+import dev.johnoreilly.fantasypremierleague.ui.bottomNavigationItems
 import dev.johnoreilly.fantasypremierleague.ui.global.FantasyPremierLeagueTheme
 import dev.johnoreilly.fantasypremierleague.ui.players.PlayersViewModel
 import dev.johnoreilly.fantasypremierleague.ui.fixtures.FixturesListView
@@ -32,31 +41,58 @@ fun MainLayout(playersViewModel: PlayersViewModel) {
     val navController = rememberNavController()
 
     FantasyPremierLeagueTheme {
-        NavHost(navController, startDestination = Screen.PlayerListScreen.title) {
-            composable(Screen.PlayerListScreen.title) {
-                PlayerListView(
-                    playersViewModel = playersViewModel,
-                    onPlayerSelected = { playerId ->
-                        navController.navigate(Screen.PlayerDetailsScreen.title + "/${playerId}")
-                    }
-                )
-            }
-            composable(
-                Screen.PlayerDetailsScreen.title + "/{playerId}",
-                arguments = listOf(navArgument("playerId") { type = NavType.IntType })
-            ) { navBackStackEntry ->
-                val playerId: Int? = navBackStackEntry.arguments?.getInt("playerId")
-                val player = playersViewModel.players.value?.first { it.id == playerId }
+        Scaffold(
+            bottomBar = {
+                BottomNavigation {
+                    val navBackStackEntry by navController.currentBackStackEntryAsState()
+                    val currentRoute = navBackStackEntry?.arguments?.getString(KEY_ROUTE)
 
-                // TODO error handling for invalid playerId edge case or when first throws an exception
-                PlayerDetailsView(
-                    player = player!!,
-                    playersViewModel = playersViewModel,
-                    popBackStack = { navController.popBackStack() }
-                )
+                    bottomNavigationItems.forEach { bottomNavigationitem ->
+                        BottomNavigationItem(
+                            icon = {
+                                Icon(
+                                    bottomNavigationitem.icon,
+                                    contentDescription = bottomNavigationitem.iconContentDescription
+                                )
+                            },
+                            selected = currentRoute == bottomNavigationitem.route,
+                            onClick = {
+                                navController.navigate(bottomNavigationitem.route) {
+                                    popUpTo = navController.graph.startDestination
+                                    launchSingleTop = true
+                                }
+                            }
+                        )
+                    }
+                }
             }
-            composable(Screen.FixtureListScreen.title) {
-                FixturesListView(playersViewModel = playersViewModel)
+        ) {
+            NavHost(navController, startDestination = Screen.PlayerListScreen.title) {
+                composable(Screen.PlayerListScreen.title) {
+                    PlayerListView(
+                        playersViewModel = playersViewModel,
+                        onPlayerSelected = { playerId ->
+                            navController.navigate(Screen.PlayerDetailsScreen.title + "/${playerId}")
+                        }
+                    )
+                }
+                composable(
+                    Screen.PlayerDetailsScreen.title + "/{playerId}",
+                    arguments = listOf(navArgument("playerId") { type = NavType.IntType })
+                ) { navBackStackEntry ->
+                    val playerId: Int? = navBackStackEntry.arguments?.getInt("playerId")
+                    val player = playersViewModel.players.value?.first { it.id == playerId }
+
+                    // TODO error handling for invalid playerId edge case or when first throws an exception
+                    PlayerDetailsView(
+                        player = player!!,
+                        playersViewModel = playersViewModel,
+                        popBackStack = { navController.popBackStack() }
+                    )
+                }
+                composable(Screen.FixtureListScreen.title) {
+                    FixturesListView(playersViewModel = playersViewModel)
+                }
             }
         }
     }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/Screen.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/Screen.kt
@@ -1,7 +1,0 @@
-package dev.johnoreilly.fantasypremierleague.ui
-
-sealed class Screen(val title: String) {
-    object PlayerListScreen : Screen("PlayerListScreen")
-    object PlayerDetailsScreen : Screen("PlayerDetailsScreen")
-    object FixtureListScreen : Screen("FixtureListScreen")
-}

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/ScreenAndBottomNavigationItems.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/ScreenAndBottomNavigationItems.kt
@@ -1,0 +1,31 @@
+package dev.johnoreilly.fantasypremierleague.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class Screen(val title: String) {
+    object PlayerListScreen : Screen("PlayerListScreen")
+    object PlayerDetailsScreen : Screen("PlayerDetailsScreen")
+    object FixtureListScreen : Screen("FixtureListScreen")
+}
+
+data class BottomNavigationitem(
+    val route: String,
+    val icon: ImageVector,
+    val iconContentDescription: String
+)
+
+val bottomNavigationItems = listOf(
+    BottomNavigationitem(
+        Screen.PlayerListScreen.title,
+        Icons.Default.Person,
+        "Player"
+    ),
+    BottomNavigationitem(
+        Screen.FixtureListScreen.title,
+        Icons.Filled.DateRange,
+        "Fixtures"
+    ),
+)

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/ui/players/PlayersListView.kt
@@ -34,8 +34,9 @@ fun PlayerListView(
         },
         bodyContent = {
             Column {
-                OutlinedTextField(
+                TextField(
                     singleLine = true,
+                    backgroundColor = MaterialTheme.colors.background,
                     value = playerSearchQuery.value,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -66,12 +67,13 @@ fun PlayerListView(
                         playersViewModel.onPlayerSearchQueryChange(it)
                     }
                 )
-
                 playerList.value?.let {
                     LazyColumn {
-                        items(items = it, itemContent = { player ->
-                            PlayerView(player, onPlayerSelected)
-                        })
+                        items(
+                            items = it,
+                            itemContent = { player ->
+                                PlayerView(player, onPlayerSelected)
+                            })
                     }
                 }
             }


### PR DESCRIPTION
### Changes
* Set bottom navigation bar with the following primary destinations:
  * `PlayersListView`
  *  `FixtureListView` 
* Configure search bar in `PlayersListView`, from `OutlineTextField` to `TextField` with the default material theme `background`.

### Upcoming changes
* Maintain multiple backstack
* Create `FixtureView`

### Screenshots
<img src="https://user-images.githubusercontent.com/32627089/106446503-53bc2d00-644e-11eb-8f5e-6982a7842f78.gif" width=350 />
