### PR TITLE
Update to Realm 0.10.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     const val ktor = "1.6.7"
     const val kotlinxSerialization = "1.3.1"
     const val koin = "3.1.4"
-    const val realm = "0.9.0"
+    const val realm = "0.10.0"
     const val kermit = "1.0.0"
     const val kotlinxDateTime = "0.3.1"
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,6 @@ pluginManagement {
         mavenCentral()
         maven(url = "https://maven.pkg.jetbrains.space/public/p/compose/dev")
     }
-
 }
 
 


### PR DESCRIPTION
This upgrades to Realm 0.10.0 and uses the new updating `copyToRealm` with `UpdatePolicy` to update existing objects instead of wiping data on each restart.