### PR TITLE
Update to Realm Kotlin 1.0.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -5,7 +5,7 @@ object Versions {
     const val ktor = "2.0.1"
     const val kotlinxSerialization = "1.3.3"
     const val koin = "3.2.0"
-    const val realm = "0.11.0"
+    const val realm = "1.0.0"
     const val kermit = "1.0.0"
     const val kotlinxDateTime = "0.3.2"
 

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
@@ -7,9 +7,12 @@ import dev.johnoreilly.common.data.remote.FantasyPremierLeagueApi
 import dev.johnoreilly.common.domain.entities.GameFixture
 import dev.johnoreilly.common.domain.entities.Player
 import dev.johnoreilly.common.domain.entities.Team
-import io.realm.*
-import io.realm.annotations.PrimaryKey
-import io.realm.notifications.ResultsChange
+import io.realm.kotlin.Realm
+import io.realm.kotlin.UpdatePolicy
+import io.realm.kotlin.ext.query
+import io.realm.kotlin.query.RealmResults
+import io.realm.kotlin.types.RealmObject
+import io.realm.kotlin.types.annotations.PrimaryKey
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import org.koin.core.component.KoinComponent
@@ -155,7 +158,7 @@ class FantasyPremierLeagueRepository : KoinComponent {
                     index = teamIndex + 1
                     name = teamDto.name
                     code = teamDto.code
-                }, updatePolicy = MutableRealm.UpdatePolicy.ALL)
+                }, updatePolicy = UpdatePolicy.ALL)
             }
 
             // store players
@@ -172,7 +175,7 @@ class FantasyPremierLeagueRepository : KoinComponent {
                     assists = player.assists
 
                     team = query<TeamDb>("code = $0", player.team_code).first().find()
-                }, updatePolicy = MutableRealm.UpdatePolicy.ALL)
+                }, updatePolicy = UpdatePolicy.ALL)
             }
 
             // store fixtures
@@ -187,7 +190,7 @@ class FantasyPremierLeagueRepository : KoinComponent {
 
                         homeTeam = teams.find { it.index == fixtureDto.team_h }
                         awayTeam = teams.find { it.index == fixtureDto.team_a }
-                    }, updatePolicy = MutableRealm.UpdatePolicy.ALL)
+                    }, updatePolicy = UpdatePolicy.ALL)
                 }
             }
 

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
@@ -11,9 +11,9 @@ import io.ktor.client.engine.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
-import io.realm.Configuration
-import io.realm.Realm
-import io.realm.RealmConfiguration
+import io.realm.kotlin.Configuration
+import io.realm.kotlin.Realm
+import io.realm.kotlin.RealmConfiguration
 import kotlinx.serialization.json.Json
 import org.koin.core.context.startKoin
 import org.koin.dsl.KoinAppDeclaration
@@ -32,7 +32,7 @@ fun commonModule(enableNetworkLogs: Boolean) = module {
     single { createJson() }
     single { createHttpClient(get(), get(), enableNetworkLogs = enableNetworkLogs) }
 
-    single<Configuration> { RealmConfiguration.with(schema = setOf(PlayerDb::class, TeamDb::class, FixtureDb::class)) }
+    single<Configuration> { RealmConfiguration.create(schema = setOf(PlayerDb::class, TeamDb::class, FixtureDb::class)) }
     single { Realm.open(get()) }
 
     single { FantasyPremierLeagueRepository() }


### PR DESCRIPTION
This PR updates to use Realm Kotlin 1.0.0 and adjusts imports according to top level package renaming/restructuring 
 as described in https://github.com/realm/realm-kotlin/blob/v1.0.0/CHANGELOG.md
