### PR TITLE
Split fixture list into gameweeks

### DIFF
--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -15,16 +15,19 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
-import androidx.navigation.compose.*
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import dev.johnoreilly.fantasypremierleague.presentation.FantasyPremierLeagueViewModel
 import dev.johnoreilly.fantasypremierleague.presentation.Screen
 import dev.johnoreilly.fantasypremierleague.presentation.bottomNavigationItems
 import dev.johnoreilly.fantasypremierleague.presentation.fixtures.FixturesListView
 import dev.johnoreilly.fantasypremierleague.presentation.fixtures.fixtureDetails.FixtureDetailsView
 import dev.johnoreilly.fantasypremierleague.presentation.global.FantasyPremierLeagueTheme
-import dev.johnoreilly.fantasypremierleague.presentation.players.PlayerListView
-import dev.johnoreilly.fantasypremierleague.presentation.FantasyPremierLeagueViewModel
 import dev.johnoreilly.fantasypremierleague.presentation.leagues.LeagueListView
+import dev.johnoreilly.fantasypremierleague.presentation.players.PlayerListView
 import dev.johnoreilly.fantasypremierleague.presentation.players.playerDetails.PlayerDetailsView
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
@@ -83,7 +86,9 @@ fun MainLayout(viewModel: FantasyPremierLeagueViewModel) {
                     fantasyPremierLeagueViewModel = viewModel,
                     onFixtureSelected = { fixtureId ->
                         navController.navigate(Screen.FixtureDetailsScreen.title + "/${fixtureId}")
-                    }
+                    },
+                    //todo Calculate current GW and pass in
+                    currentGameweek = 1
                 )
             }
             composable(

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/FantasyPremierLeagueViewModel.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/FantasyPremierLeagueViewModel.kt
@@ -1,17 +1,12 @@
 package dev.johnoreilly.fantasypremierleague.presentation
 
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.lifecycle.*
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dev.johnoreilly.common.data.model.LeagueResultDto
-import dev.johnoreilly.common.data.model.LeagueStandingsDto
 import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
 import dev.johnoreilly.common.domain.entities.GameFixture
 import dev.johnoreilly.common.domain.entities.Player
 import dev.johnoreilly.common.domain.entities.PlayerPastHistory
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 
@@ -21,23 +16,24 @@ class FantasyPremierLeagueViewModel(
 ) : ViewModel() {
 
     val searchQuery = MutableStateFlow("")
-    val playerList: StateFlow<List<Player>> = searchQuery.debounce(250).flatMapLatest { searchQuery ->
-        repository.playerList.mapLatest { playerList ->
-            playerList
-                .filter { it.name.contains(searchQuery, ignoreCase = true) }
-                .sortedByDescending { it.points }
-        }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+    val playerList: StateFlow<List<Player>> =
+        searchQuery.debounce(250).flatMapLatest { searchQuery ->
+            repository.playerList.mapLatest { playerList ->
+                playerList
+                    .filter { it.name.contains(searchQuery, ignoreCase = true) }
+                    .sortedByDescending { it.points }
+            }
+        }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     val fixturesList = repository.fixtureList
+
+    val gameweekToFixtures = repository.gameweekToFixtures
 
     val leagues: StateFlow<List<String>> = repository.leagues
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 
     var leagueStandings = MutableStateFlow((emptyList<LeagueResultDto>()))
     var leagueName = MutableStateFlow("")
-
-
 
     private val _isRefreshing = MutableStateFlow(false)
     val isRefreshing: StateFlow<Boolean>

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
@@ -1,35 +1,102 @@
 package dev.johnoreilly.fantasypremierleague.presentation.fixtures
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.Scaffold
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.johnoreilly.fantasypremierleague.presentation.FantasyPremierLeagueViewModel
 
 @Composable
 fun FixturesListView(
     fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel,
-    onFixtureSelected: (fixtureId: Int) -> Unit
+    onFixtureSelected: (fixtureId: Int) -> Unit,
+    currentGameweek: Int = 1
 ) {
-    val pastFixturesState = fantasyPremierLeagueViewModel.fixturesList.collectAsState()
-
+    val fixturesState = fantasyPremierLeagueViewModel.gameweekToFixtures.collectAsState()
+    val gameweek = remember { mutableStateOf(currentGameweek) }
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Fantasy Premier League") })
         }) {
-            Column {
-                LazyColumn {
-                    items(items = pastFixturesState.value, itemContent = { fixture ->
+        Column {
+            GameweekSelector(selectedGameweek = gameweek.value, onGameweekChanged = {
+                if (it is GameweekChange.PastGameweek) gameweek.value -= 1 else gameweek.value += 1
+            })
+            LazyColumn {
+                items(
+                    items = fixturesState.value[gameweek.value] ?: emptyList(),
+                    itemContent = { fixture ->
                         FixtureView(
                             fixture = fixture,
                             onFixtureSelected = onFixtureSelected
                         )
                     })
-                }
             }
         }
+    }
+}
+
+@Composable
+fun GameweekSelector(
+    selectedGameweek: Int,
+    onGameweekChanged: (gameweekChange: GameweekChange) -> Unit
+) {
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 10.dp),
+        horizontalArrangement = Arrangement.SpaceAround,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+
+        if (selectedGameweek > 1) {
+            IconButton(
+                modifier = Modifier
+                    .width(30.dp)
+                    .background(color = Color.LightGray),
+                onClick = { onGameweekChanged(GameweekChange.PastGameweek) }) {
+                Icon(Icons.Filled.ArrowBack, contentDescription = "Back arrow")
+            }
+        } else {
+            Spacer(modifier = Modifier.width(30.dp))
+        }
+
+        Text(
+            text = "Gameweek $selectedGameweek",
+            fontWeight = FontWeight.Normal,
+            fontSize = 20.sp
+        )
+
+        if (selectedGameweek < 38) {
+            IconButton(
+                modifier = Modifier
+                    .width(30.dp)
+                    .background(color = Color.LightGray),
+                onClick = { onGameweekChanged(GameweekChange.NextGameweek) }) {
+                Icon(Icons.Filled.ArrowForward, contentDescription = "Forward arrow")
+            }
+        } else {
+            Spacer(modifier = Modifier.width(30.dp))
+        }
+    }
+}
+
+sealed class GameweekChange() {
+    object NextGameweek : GameweekChange()
+    object PastGameweek : GameweekChange()
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/domain/entities/GameFixture.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/domain/entities/GameFixture.kt
@@ -10,5 +10,6 @@ data class GameFixture(
     val homeTeamPhotoUrl: String,
     val awayTeamPhotoUrl: String,
     val homeTeamScore: Int?,
-    val awayTeamScore: Int?
+    val awayTeamScore: Int?,
+    val event: Int?
 )


### PR DESCRIPTION
The fixture list is now split into gameweeks with simple arrow buttons to navigate between the gameweeks. Need to do some further work to get in the current GW rather than starting at 1.


![new-fixture-list-screenshot](https://user-images.githubusercontent.com/42590007/190876412-31ace2fe-0de1-48d9-a2c9-6da5da7fbf75.png)

