### PR TITLE
show fixtures by gameweek in SwiftUI client

### DIFF
--- a/ios/FantasyPremierLeague/FantasyPremierLeague/Fixtures/FixtureListView.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/Fixtures/FixtureListView.swift
@@ -9,23 +9,46 @@ extension GameFixture: Identifiable { }
 struct FixtureListView: View {
     @ObservedObject var viewModel: FantasyPremierLeagueViewModel
     
+    @State var gameWeek = 1
+    
     var body: some View {
-        NavigationView {
-            List(viewModel.fixtureList) { fixture in
-                NavigationLink(destination: FixtureDetailView(fixture: fixture)) {
-                    FixtureView(fixture: fixture)
+        VStack {
+            HStack {
+                Button(action: {
+                    if (gameWeek > 1) {
+                        gameWeek = gameWeek - 1
+                    }
+                }) {
+                  Image(systemName: "arrow.left")
+                }
+
+                Text("Gameweek \(gameWeek)")
+                
+                Button(action: {
+                    if (gameWeek < 38) {
+                        gameWeek = gameWeek + 1
+                    }
+                }) {
+                  Image(systemName: "arrow.right")
                 }
             }
-            .navigationBarTitle(Text("Fixtues"))
+            NavigationView {
+                List(viewModel.gameWeekFixtures[gameWeek] ?? []) { fixture in
+                    NavigationLink(destination: FixtureDetailView(fixture: fixture)) {
+                        FixtureView(fixture: fixture)
+                    }
+                }
+                .navigationBarTitle(Text("Fixtues"))
+                .onAppear {
+                    UITableView.appearance().separatorStyle = .none
+                }
+                .task {
+                    await viewModel.getGameWeekFixtures()
+                }
+            }
             .onAppear {
-                UITableView.appearance().separatorStyle = .none                
+                UITableView.appearance().separatorStyle = .none
             }
-            .task {
-                await viewModel.getFixtures()
-            }
-        }
-        .onAppear {
-            UITableView.appearance().separatorStyle = .none
         }
     }
 }

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/ViewModel.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/ViewModel.swift
@@ -12,6 +12,8 @@ extension PlayerPastHistory: Identifiable { }
 class FantasyPremierLeagueViewModel: ObservableObject {
     @Published var playerList = [Player]()
     @Published var fixtureList = [GameFixture]()
+    @Published var gameWeekFixtures = [Int: [GameFixture]]()
+    
     @Published var playerHistory = [PlayerPastHistory]()
     @Published var leagueStandings: LeagueStandingsDto? = nil
     @Published var eventStatusList: EventStatusListDto? = nil
@@ -41,7 +43,7 @@ class FantasyPremierLeagueViewModel: ObservableObject {
         }
         
         Task {
-            self.eventStatusList = try await asyncFunction(for: repository.getEventStatusNative())
+            self.eventStatusList = try await asyncFunction(for: repository.getEventStatusNative())                        
         }
     }
 
@@ -100,6 +102,20 @@ class FantasyPremierLeagueViewModel: ObservableObject {
             print("Failed with error: \(error)")
         }
     }
+
+    
+    func getGameWeekFixtures() async {
+        do {
+            let stream = asyncStream(for: repository.gameweekToFixturesNative)
+            for try await data in stream {
+                self.gameWeekFixtures = data as! [Int : [GameFixture]]
+            }
+        } catch {
+            print("Failed with error: \(error)")
+        }
+    }
+
+    
 }
 
 


### PR DESCRIPTION
Hacked updates to SwiftUI code to allow browsing fixtures by game week (building on changes @HoinzeyBear made for Android client).  Had layout issues with those buttons inside `NavigationView` so put above for now.

![Simulator Screen Shot - iPhone 12 Pro Max - 2022-09-18 at 10 59 04](https://user-images.githubusercontent.com/6302/190896548-c8b0d515-5fd2-4c71-a504-1341173771b4.png)
