### PR TITLE
Store current gameweek and fetch it when going to fixture list page

### DIFF
--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/MainActivity.kt
@@ -86,9 +86,7 @@ fun MainLayout(viewModel: FantasyPremierLeagueViewModel) {
                     fantasyPremierLeagueViewModel = viewModel,
                     onFixtureSelected = { fixtureId ->
                         navController.navigate(Screen.FixtureDetailsScreen.title + "/${fixtureId}")
-                    },
-                    //todo Calculate current GW and pass in
-                    currentGameweek = 1
+                    }
                 )
             }
             composable(

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/FantasyPremierLeagueViewModel.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/FantasyPremierLeagueViewModel.kt
@@ -29,6 +29,9 @@ class FantasyPremierLeagueViewModel(
 
     val gameweekToFixtures = repository.gameweekToFixtures
 
+    val currentGameweek: Int
+        get() = repository.currentGameweek
+
     val leagues: StateFlow<List<String>> = repository.leagues
         .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
 

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
@@ -23,11 +23,10 @@ import dev.johnoreilly.fantasypremierleague.presentation.FantasyPremierLeagueVie
 @Composable
 fun FixturesListView(
     fantasyPremierLeagueViewModel: FantasyPremierLeagueViewModel,
-    onFixtureSelected: (fixtureId: Int) -> Unit,
-    currentGameweek: Int = 1
+    onFixtureSelected: (fixtureId: Int) -> Unit
 ) {
     val fixturesState = fantasyPremierLeagueViewModel.gameweekToFixtures.collectAsState()
-    val gameweek = remember { mutableStateOf(currentGameweek) }
+    val gameweek = remember { mutableStateOf(fantasyPremierLeagueViewModel.currentGameweek) }
     Scaffold(
         topBar = {
             TopAppBar(title = { Text("Fixtures") })

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
@@ -81,11 +81,15 @@ class FantasyPremierLeagueRepository : KoinComponent {
     private val _fixtureList = MutableStateFlow<List<GameFixture>>(emptyList())
     val fixtureList = _fixtureList.asStateFlow()
 
-    private val _gameweekToFixtureMap = MutableStateFlow<Map<Int,List<GameFixture>>>(emptyMap())
-    val gameweekToFixtures: StateFlow<Map<Int, List<GameFixture>>> = _gameweekToFixtureMap.asStateFlow()
+    private val _gameweekToFixtureMap = MutableStateFlow<Map<Int, List<GameFixture>>>(emptyMap())
+    val gameweekToFixtures: StateFlow<Map<Int, List<GameFixture>>> =
+        _gameweekToFixtureMap.asStateFlow()
 
     val leagues = appSettings.leagues
 
+    private var _currentGameweek: Int? = null
+    val currentGameweek: Int
+        get() = _currentGameweek ?: 1
 
     init {
         coroutineScope.launch {
@@ -95,7 +99,7 @@ class FantasyPremierLeagueRepository : KoinComponent {
                 realm.query<TeamDb>().asFlow()
                     .map { it.list }
                     .collect { it: RealmResults<TeamDb> ->
-                    _teamList.value = it.toList().map {
+                        _teamList.value = it.toList().map {
                         Team(it.id, it.index, it.name, it.code)
                     }
                 }
@@ -206,6 +210,9 @@ class FantasyPremierLeagueRepository : KoinComponent {
                 }, updatePolicy = UpdatePolicy.ALL)
             }
 
+            //store current gameweek
+            _currentGameweek = bootstrapStaticInfoDto.events.first { it.is_current }.id
+
             // store fixtures
             val teams = query<TeamDb>().find().toList()
             fixtures.forEach { fixtureDto ->
@@ -222,7 +229,6 @@ class FantasyPremierLeagueRepository : KoinComponent {
                     }, updatePolicy = UpdatePolicy.ALL)
                 }
             }
-
         }
     }
 


### PR DESCRIPTION
Store current gameweek and fetch it when going to fixture list page s…o you view current gameweek's fixtures.

One issue is that as the call to `loadData` takes so long, you can enter the fixtures page before this value has been set, landing you on GW1 rather than the current GW. 

Not sure if we want to explore ways around that ?