### PR TITLE
Standardise the length of our placeholder data

### DIFF
--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
@@ -125,10 +125,10 @@ private val placeholderFixtureList = listOf(
         event = 0
     ),
     GameFixture(
-        id = 2,
+        id = 1,
         localKickoffTime = placeholderKickoffTime,
-        homeTeam = "Brighton",
-        awayTeam = "Fulham",
+        homeTeam = "Liverpool",
+        awayTeam = "Manchester United",
         homeTeamPhotoUrl = "",
         awayTeamPhotoUrl = "",
         homeTeamScore = null,
@@ -136,10 +136,10 @@ private val placeholderFixtureList = listOf(
         event = 0
     ),
     GameFixture(
-        id = 3,
+        id = 1,
         localKickoffTime = placeholderKickoffTime,
-        homeTeam = "Chelsea",
-        awayTeam = "Crystal Palace",
+        homeTeam = "Liverpool",
+        awayTeam = "Manchester United",
         homeTeamPhotoUrl = "",
         awayTeamPhotoUrl = "",
         homeTeamScore = null,
@@ -147,10 +147,10 @@ private val placeholderFixtureList = listOf(
         event = 0
     ),
     GameFixture(
-        id = 4,
+        id = 1,
         localKickoffTime = placeholderKickoffTime,
-        homeTeam = "Tottenham",
-        awayTeam = "Wolves",
+        homeTeam = "Liverpool",
+        awayTeam = "Manchester United",
         homeTeamPhotoUrl = "",
         awayTeamPhotoUrl = "",
         homeTeamScore = null,
@@ -158,10 +158,10 @@ private val placeholderFixtureList = listOf(
         event = 0
     ),
     GameFixture(
-        id = 5,
+        id = 1,
         localKickoffTime = placeholderKickoffTime,
-        homeTeam = "Everton",
-        awayTeam = "Southampton",
+        homeTeam = "Liverpool",
+        awayTeam = "Manchester United",
         homeTeamPhotoUrl = "",
         awayTeamPhotoUrl = "",
         homeTeamScore = null,

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/players/PlayerView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/players/PlayerView.kt
@@ -47,6 +47,7 @@ fun PlayerView(
                 text = player.name,
                 style = MaterialTheme.typography.h6
             )
+            Spacer(modifier = Modifier.size(1.dp))
             Text(
                 modifier = Modifier.placeholder(visible = isDataLoading, lowfidelitygray),
                 text = player.team,

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/players/PlayersListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/players/PlayersListView.kt
@@ -85,27 +85,27 @@ fun PlayerListView(
 
 private val placeHolderPlayerList = listOf(
     Player(
-        1, "Harry Kane", "Spurs",
-        "", 99, 10.0, 14, 1
+        1, "Jordan Henderson", "Liverpool",
+        "", 95, 10.0, 14, 1
     ),
     Player(
         1, "Jordan Henderson", "Liverpool",
         "", 95, 10.0, 14, 1
     ),
     Player(
-        1, "Scott McTominay", "Manchester United",
-        "", 90, 10.0, 14, 1
+        1, "Jordan Henderson", "Liverpool",
+        "", 95, 10.0, 14, 1
     ),
     Player(
-        1, "Kevin DeBruyne", "Manchester City",
-        "", 85, 10.0, 14, 1
+        1, "Jordan Henderson", "Liverpool",
+        "", 95, 10.0, 14, 1
     ),
     Player(
-        1, "Lewis Dunk", "Brighton",
-        "", 66, 10.0, 14, 1
+        1, "Jordan Henderson", "Liverpool",
+        "", 95, 10.0, 14, 1
     ),
     Player(
-        1, "Gabriel Jesus", "Arsenal",
-        "", 14, 10.0, 14, 1
-    ),
+        1, "Jordan Henderson", "Liverpool",
+        "", 95, 10.0, 14, 1
+    )
 )


### PR DESCRIPTION
Standardise the length of our placeholder data so the UI looks nicer.

Added in a slight spacer so there is a distinction between the player name blob and their team blob.

![low-fidelity-accompanist](https://user-images.githubusercontent.com/42590007/192149873-a6052514-6c39-4b79-a25d-47cda7c7be25.png)
