### PR TITLE
Cleaner looking fixture list UI.

### DIFF
--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixtureView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixtureView.kt
@@ -1,8 +1,10 @@
 package dev.johnoreilly.fantasypremierleague.presentation.fixtures
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -13,12 +15,14 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.google.accompanist.placeholder.placeholder
 import dev.johnoreilly.common.domain.entities.GameFixture
 import dev.johnoreilly.fantasypremierleague.presentation.global.lowfidelitygray
+import dev.johnoreilly.fantasypremierleague.presentation.global.maroon200
 
 @Composable
 fun FixtureView(
@@ -52,19 +56,19 @@ fun FixtureView(
                     fixture.homeTeamPhotoUrl
                 )
                 Text(
-                    text = "(${fixture.homeTeamScore})",
+                    text = "${fixture.homeTeamScore}",
                     fontWeight = FontWeight.Bold,
                     fontSize = 25.sp,
                     color = MaterialTheme.colors.onSurface
                 )
-                Text(
-                    modifier = Modifier.placeholder(visible = isDataLoading, lowfidelitygray),
-                    text = "vs",
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 25.sp
+                Divider(
+                    modifier = Modifier
+                        .heightIn(min = 20.dp, max = 30.dp)
+                        .width(1.dp)
+                        .background(color = maroon200)
                 )
                 Text(
-                    text = "(${fixture.awayTeamScore})",
+                    text = "${fixture.awayTeamScore}",
                     fontWeight = FontWeight.Bold,
                     fontSize = 25.sp,
                     color = MaterialTheme.colors.onSurface
@@ -117,6 +121,29 @@ fun ClubInFixtureView(
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             color = MaterialTheme.colors.onSurface
+        )
+    }
+}
+
+@Preview
+@Composable
+fun PreviewFixtureView() {
+    val placeholderKickoffTime = kotlinx.datetime.LocalDateTime(2022, 9, 5, 13, 30, 0)
+    Column(modifier = Modifier.height(200.dp)) {
+        FixtureView(
+            fixture = GameFixture(
+                id = 1,
+                localKickoffTime = placeholderKickoffTime,
+                homeTeam = "Liverpool",
+                "Spurs",
+                "",
+                "",
+                3,
+                0,
+                5
+            ),
+            onFixtureSelected = {},
+            isDataLoading = false
         )
     }
 }

--- a/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
+++ b/app/src/main/java/dev/johnoreilly/fantasypremierleague/presentation/fixtures/FixturesListView.kt
@@ -1,20 +1,18 @@
 package dev.johnoreilly.fantasypremierleague.presentation.fixtures
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
+import androidx.compose.material.icons.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -22,6 +20,7 @@ import com.google.accompanist.placeholder.placeholder
 import dev.johnoreilly.common.domain.entities.GameFixture
 import dev.johnoreilly.fantasypremierleague.presentation.FantasyPremierLeagueViewModel
 import dev.johnoreilly.fantasypremierleague.presentation.global.lowfidelitygray
+import dev.johnoreilly.fantasypremierleague.presentation.global.maroon200
 
 @Composable
 fun FixturesListView(
@@ -77,10 +76,13 @@ fun GameweekSelector(
         if (selectedGameweek > 1) {
             IconButton(
                 modifier = Modifier
-                    .width(30.dp)
-                    .background(color = Color.LightGray),
+                    .width(30.dp),
                 onClick = { onGameweekChanged(GameweekChange.PastGameweek) }) {
-                Icon(Icons.Filled.ArrowBack, contentDescription = "Back arrow")
+                Icon(
+                    Icons.Filled.KeyboardArrowLeft,
+                    contentDescription = "Back arrow",
+                    tint = maroon200
+                )
             }
         } else {
             Spacer(modifier = Modifier.width(30.dp))
@@ -95,10 +97,13 @@ fun GameweekSelector(
         if (selectedGameweek < 38) {
             IconButton(
                 modifier = Modifier
-                    .width(30.dp)
-                    .background(color = Color.LightGray),
+                    .width(30.dp),
                 onClick = { onGameweekChanged(GameweekChange.NextGameweek) }) {
-                Icon(Icons.Filled.ArrowForward, contentDescription = "Forward arrow")
+                Icon(
+                    Icons.Filled.KeyboardArrowRight,
+                    contentDescription = "Forward arrow",
+                    tint = maroon200
+                )
             }
         } else {
             Spacer(modifier = Modifier.width(30.dp))


### PR DESCRIPTION
Removed the "Vs" and replaced with vertical bar. Also changed icon to go between gameweeks and removed background box

New look:
![edited-fixture-list-view](https://user-images.githubusercontent.com/42590007/192165430-b62ae868-b37a-4c29-838e-b45f3212ba64.png)

Old Look:
![new-fixture-list-screenshot](https://user-images.githubusercontent.com/42590007/192165440-98f9ae3b-4f91-4788-bd2a-0fe0818c75be.png)
