### PR TITLE
Optimise repositories declarations

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,13 +1,30 @@
 pluginManagement {
-    listOf(repositories, dependencyResolutionManagement.repositories).forEach {
-        it.apply {
-            google()
-            gradlePluginPortal()
-            mavenCentral()
-            maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
-            maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
-            maven("https://androidx.dev/storage/compose-compiler/repository")
+    repositories {
+        google {
+            mavenContent {
+                includeGroupByRegex(".*google.*")
+                includeGroupByRegex(".*android.*")
+            }
         }
+
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupByRegex(".*google.*")
+                includeGroupByRegex(".*android.*")
+            }
+        }
+
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/wasm/experimental")
+        maven("https://androidx.dev/storage/compose-compiler/repository")
     }
 }
 


### PR DESCRIPTION
Previously the same repositories for plugins as well as for compile/runtime dependencies were used.

The order of repositories was suboptimal as every dependency was requested in the following order:

-> google(): Only contains Android dependencies that we care about
-> gradlePluginPortal(): Should only be used to resolve Gradle plugins
-> mavenCental(): OK