### PR TITLE
Fixing SwiftUI ViewModel data loading

### DIFF
--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/FixturesViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/FixturesViewModel.kt
@@ -16,7 +16,7 @@ open class FixturesViewModel : ViewModel(), KoinComponent {
 
     val gameWeekFixtures = repository.getFixtures().map {
         it.groupBy { it.event }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyMap())
+    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyMap())
 
     val currentGameweek: StateFlow<Int>
         get() = repository.currentGameweek

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/LeaguesViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/LeaguesViewModel.kt
@@ -18,14 +18,14 @@ open class LeaguesViewModel : ViewModel(), KoinComponent {
 
 
     val leagues: StateFlow<List<String>> = repository.leagues
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
 
     var leagueStandings = repository.leagues.map { leagues ->
         leagues.map { leagueId ->
             repository.getLeagueStandings(leagueId.trim().toInt())
         }
-    }.stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     private val _isRefreshing = MutableStateFlow(false)
 

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/PlayerListViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/PlayerListViewModel.kt
@@ -28,7 +28,7 @@ open class PlayerListViewModel : ViewModel(), KoinComponent {
     private val repository: FantasyPremierLeagueRepository by inject()
 
     val allPlayers = repository.getPlayers()
-        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
     val searchQuery = MutableStateFlow("")
     val playerListUIState: StateFlow<PlayerListUIState> =
@@ -43,7 +43,7 @@ open class PlayerListViewModel : ViewModel(), KoinComponent {
                     PlayerListUIState.Loading
                 }
             }
-        }.stateIn(viewModelScope, SharingStarted.Eagerly, PlayerListUIState.Loading)
+        }.stateIn(viewModelScope, SharingStarted.Lazily, PlayerListUIState.Loading)
 
     fun onPlayerSearchQueryChange(query: String) {
         searchQuery.value = query


### PR DESCRIPTION
See issue : https://github.com/joreilly/FantasyPremierLeague/issues/229
ViewModel data are loaded on init of the view, but on SwiftUI data are normally loaded on view appear 
We are replacing SharingStarted.Eagerly with SharingStarted.Lazily 
Now, the data is loaded when the view is bind to the viewmodel

This is working on SwiftUI and Compose.
