### PR TITLE
Align SwiftUI ViewModel behavior to KMP ViewModel

### DIFF
--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/CancelViewModelScope.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/CancelViewModelScope.kt
@@ -1,0 +1,22 @@
+package dev.johnoreilly.common.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import co.touchlab.kermit.Logger
+import co.touchlab.kermit.Logger.Companion.i
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import org.koin.core.parameter.parametersOf
+import org.koin.mp.KoinPlatform.getKoin
+
+/**
+ * Cancel view model scope as it can't be automatically cancelled in iOS
+ *
+ * Should be call from swift iOS code to simulate the cleanup of the view model
+ * iOS Target
+ */
+fun ViewModel.cancelViewModelScope() {
+    if (viewModelScope.isActive) {
+        viewModelScope.cancel("Manually cancelling viewModelScope for iOS Target")
+    }
+}

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/CancelViewModelScope.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/CancelViewModelScope.kt
@@ -2,12 +2,8 @@ package dev.johnoreilly.common.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import co.touchlab.kermit.Logger
-import co.touchlab.kermit.Logger.Companion.i
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.isActive
-import org.koin.core.parameter.parametersOf
-import org.koin.mp.KoinPlatform.getKoin
 
 /**
  * Cancel view model scope as it can't be automatically cancelled in iOS

--- a/ios/FantasyPremierLeague/FantasyPremierLeague.xcodeproj/project.pbxproj
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		113C59A62C05E19700101B4E /* SharedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 113C59A52C05E19700101B4E /* SharedViewModel.swift */; };
 		1A0F7AE225C5C96F00EB34CF /* FantasyPremierLeagueApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0F7AE125C5C96F00EB34CF /* FantasyPremierLeagueApp.swift */; };
 		1A0F7AE425C5C96F00EB34CF /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0F7AE325C5C96F00EB34CF /* ContentView.swift */; };
 		1A0F7AE625C5C97000EB34CF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1A0F7AE525C5C97000EB34CF /* Assets.xcassets */; };
@@ -22,6 +23,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		113C59A52C05E19700101B4E /* SharedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedViewModel.swift; sourceTree = "<group>"; };
 		1A0F7ADE25C5C96F00EB34CF /* FantasyPremierLeague.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FantasyPremierLeague.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1A0F7AE125C5C96F00EB34CF /* FantasyPremierLeagueApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FantasyPremierLeagueApp.swift; sourceTree = "<group>"; };
 		1A0F7AE325C5C96F00EB34CF /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -77,6 +79,7 @@
 				1A0F7AEA25C5C97000EB34CF /* Info.plist */,
 				1A0F7AE725C5C97000EB34CF /* Preview Content */,
 				1AD9A1242AA355F500B14FE3 /* SettingsView.swift */,
+				113C59A52C05E19700101B4E /* SharedViewModel.swift */,
 			);
 			path = FantasyPremierLeague;
 			sourceTree = "<group>";
@@ -214,6 +217,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				1A45B23B25CB3BF100A8C613 /* PlayerDetailsView.swift in Sources */,
+				113C59A62C05E19700101B4E /* SharedViewModel.swift in Sources */,
 				1A1D2B32289EA235000149CC /* LeagueListView.swift in Sources */,
 				1A45B23825CB3BBE00A8C613 /* PlayerListView.swift in Sources */,
 				1AD9A1252AA355F500B14FE3 /* SettingsView.swift in Sources */,

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/Fixtures/FixtureListView.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/Fixtures/FixtureListView.swift
@@ -6,7 +6,7 @@ import FantasyPremierLeagueKit
 extension GameFixture: Identifiable { }
 
 struct FixtureListView: View {
-    @State var viewModel = FixturesViewModel()
+    @StateObject var viewModel = SharedViewModel<FixturesViewModel>()
     
     @State var gameWeekFixtures = [Int: [GameFixture]]()
     
@@ -40,7 +40,7 @@ struct FixtureListView: View {
                         UITableView.appearance().separatorStyle = .none
                     }
                     .task {
-                        for await data in viewModel.gameWeekFixtures {
+                        for await data in viewModel.instance.gameWeekFixtures {
                             gameWeekFixtures = data as! [Int : [GameFixture]]
                         }
                     }

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/Leagues/LeagueListView.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/Leagues/LeagueListView.swift
@@ -10,7 +10,7 @@ extension LeagueStandingsDto: Identifiable { }
 
 
 struct LeagueListView: View {
-    @State var viewModel = LeaguesViewModel()
+    @StateObject var viewModel = SharedViewModel<LeaguesViewModel>()
     
     @State var leagueStandingsList = [LeagueStandingsDto]()
     @State var eventStatusList = [EventStatusDto]()
@@ -51,9 +51,9 @@ struct LeagueListView: View {
             )
             .task {
                 do {
-                    try await eventStatusList = viewModel.getEventStatus()
+                    try await eventStatusList = viewModel.instance.getEventStatus()
                     
-                    for await data in viewModel.leagueStandings {
+                    for await data in viewModel.instance.leagueStandings {
                         leagueStandingsList = data
                     }
                 } catch {

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/Players/PlayerListView.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/Players/PlayerListView.swift
@@ -17,12 +17,12 @@ struct MyPropertyWrapper: DynamicProperty {
 extension Player: Identifiable { }
 
 struct PlayerListView: View {
-    @State var viewModel = PlayerListViewModel()
+    @StateObject var viewModel = SharedViewModel<PlayerListViewModel>()
     
     var body: some View {
         NavigationView {
             VStack {
-                Observing(viewModel.playerListUIState) { playerListUIState in
+                Observing(viewModel.instance.playerListUIState) { playerListUIState in
                     switch onEnum(of: playerListUIState) {
                     case .loading:
                         ProgressView()

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/SettingsView.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/SettingsView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import FantasyPremierLeagueKit
 
 struct SettingsView: View {
-    @State var viewModel = LeaguesViewModel()
+    @StateObject var viewModel = SharedViewModel<LeaguesViewModel>()
     @State var leagueListString = ""
     
     var body: some View {
@@ -12,7 +12,7 @@ struct SettingsView: View {
                 
                 Button("Save") {
                     let leagues = leagueListString.components(separatedBy:", ")
-                    viewModel.updateLeagues(leagues: leagues)
+                    viewModel.instance.updateLeagues(leagues: leagues)
                 }
             }
             .navigationBarTitle("Settings")

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/SharedViewModel.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/SharedViewModel.swift
@@ -2,7 +2,7 @@
 //  SharedViewModel.swift
 //  FantasyPremierLeague
 //
-//  Created by François Dabonot on 28/05/2024.
+//  Created by frankois944 on 28/05/2024.
 //
 
 import Foundation

--- a/ios/FantasyPremierLeague/FantasyPremierLeague/SharedViewModel.swift
+++ b/ios/FantasyPremierLeague/FantasyPremierLeague/SharedViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  SharedViewModel.swift
+//  FantasyPremierLeague
+//
+//  Created by François Dabonot on 28/05/2024.
+//
+
+import Foundation
+import FantasyPremierLeagueKit
+
+/**
+ Wrapping the kotlin viewmodel inside an ObservableObject to simulate the lifecycle of a SwiftUI viewModel
+ */
+class SharedViewModel<T : Lifecycle_viewmodelViewModel> : ObservableObject {
+    
+    let instance: T
+    
+    init(_ viewModel: T = .init()) {
+        self.instance = viewModel
+    }
+    
+    deinit {
+        // cancel the scope of the viewmodel
+        self.instance.cancelViewModelScope()
+        // call `onCleared` viewmodel event
+        self.instance.onCleared()
+    }
+}


### PR DESCRIPTION
from issue : https://github.com/joreilly/FantasyPremierLeague/issues/231

On Shared project :
- Add an extension method `ViewModel.cancelViewModelScope` which cancel the viewModelScope
It will be called from SwiftUI when the deinit of the viewmodel is done

On iOS :
 - Wrapping a Kotlin viewmodel inside an ObservableObject on generic way
Now, the KMP viewModel lifecycle is mapped with the SwiftUI viewModel lifecycle

We're using a `@StateObject` and not a `@State` to hold the viewmodel as it's the best way to handle `ObservableObject` as intented by SwiftUI.

the issue https://github.com/joreilly/FantasyPremierLeague/issues/229 is now useless with this upgrade.
