### PR TITLE
Migrate to AGP 9.0 with KMP library plugin

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -9,11 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 17
+    - name: set up JDK 24
       uses: actions/setup-java@v4
       with:
         distribution: 'zulu'
-        java-version: 17
+        java-version: 24
     - name: Build android app
       run: ./gradlew assembleDebug
     - name: Run Unit Tests

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: 17
+          java-version: 24
       - name: Build iOS app
         run: xcodebuild -allowProvisioningUpdates -workspace ios/FantasyPremierLeague/FantasyPremierLeague.xcodeproj/project.xcworkspace -configuration Debug -scheme FantasyPremierLeague -sdk iphoneos -destination name='iPhone 15 Pro' build
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,13 +1,12 @@
 @file:Suppress("UnstableApiUsage")
 
 plugins {
-    id("com.android.application")
-    kotlin("android")
+    alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
 }
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(24)
 }
 
 android {
@@ -55,7 +54,8 @@ android {
                 "/META-INF/INDEX.LIST",
                 "/META-INF/versions/**",
                 "/META-INF/io.netty.versions.properties",
-                "/META-INF/{AL2.0,LGPL2.1}",
+                "/META-INF/AL2.0",
+                "/META-INF/LGPL2.1",
                 "/META-INF/DEPENDENCIES",
             )
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.kotlin.multiplatform.library) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.jetbrainsCompose) apply false

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -9,24 +9,12 @@ plugins {
     alias(libs.plugins.room)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
-    id("com.android.library")
+    alias(libs.plugins.android.kotlin.multiplatform.library)
 }
 
 kotlin {
-    jvmToolchain(17)
-}
+    jvmToolchain(24)
 
-android {
-    compileSdk = libs.versions.compileSdk.get().toInt()
-    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
-    defaultConfig {
-        minSdk = libs.versions.minSdk.get().toInt()
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-    namespace = "dev.johnoreilly.common"
-}
-
-kotlin {
     listOf(
         iosX64(),
         iosArm64(),
@@ -38,7 +26,14 @@ kotlin {
         }
     }
 
-    androidTarget()
+    android {
+        namespace = "dev.johnoreilly.common"
+        compileSdk = libs.versions.compileSdk.get().toInt()
+        minSdk = libs.versions.minSdk.get().toInt()
+        androidResources {
+            enable = true
+        }
+    }
     jvm()
 
     sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,6 @@
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
-android.useAndroidX=true
-android.enableJetifier=false
 
-kotlin.mpp.androidSourceSetLayoutVersion=2
 kotlin.native.toolchain.enabled=false
 
 org.jetbrains.compose.experimental.uikit.enabled=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [versions]
 kotlin = "2.3.0"
-ksp = "2.3.0"
+ksp = "2.3.6"
 kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
 kotlinx-dateTime = "0.7.1-0.6.x-compat"
 
-androidGradlePlugin = "8.12.3"
+androidGradlePlugin = "9.0.1"
 koalaplot = "0.9.1"
 koin = "4.1.1"
 ktor = "3.3.3"
@@ -92,7 +92,7 @@ ktor-common = ["ktor-client-core", "ktor-client-json", "ktor-client-logging", "k
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
-android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "androidGradlePlugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Replace `com.android.library` with `com.android.kotlin.multiplatform.library` in the `common` module and move the Android config into `kotlin { android { } }`.
- Add `androidResources { enable = true }` — required under the new plugin so Compose Multiplatform's generated resources (e.g. `strings.commonMain.cvr` used by `PlayerDetailsViewShared`) get packaged. Without it the player details screen crashes with `MissingResourceException`.
- Bump Gradle 9.0.0 → 9.1.0, AGP 8.12.3 → 9.0.1, KSP 2.3.0 → 2.3.6, JVM toolchain 17/21 → 24.
- Drop `gradle.properties` entries that are no longer needed under the new plugin (`android.useAndroidX`, `android.enableJetifier`, `kotlin.mpp.androidSourceSetLayoutVersion`).
