### PR TITLE
Update Koog prompt executors to 1.1.1-beta

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ okalgo = "0.0.2"
 kotlinStatistics = "1.2.1"
 mcp = "0.14.0"
 koogAgents = "1.1.1"
-koogExecutors = "1.0.0-beta"
+koogExecutors = "1.1.1-beta"
 shadowPlugin = "9.6.1"
 
 


### PR DESCRIPTION
## Summary
Aligns the Koog prompt-executor modules with `koog-agents` 1.1.1 (already pinned) and the other Koog samples:
- `prompt-executor-llms-all` 1.0.0-beta → **1.1.1-beta**

## Test plan
- [x] `./gradlew assembleDebug`
- [x] `./gradlew test`
- [x] `./gradlew :common:compileKotlinIosSimulatorArm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)