### PR TITLE
Add Koog agent chat UI (FPL Assistant)

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,6 +1,8 @@
 @file:OptIn(ExperimentalKotlinGradlePluginApi::class)
 
+import com.codingfeline.buildkonfig.compiler.FieldSpec
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -10,6 +12,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.android.kotlin.multiplatform.library)
+    alias(libs.plugins.buildkonfig)
 }
 
 kotlin {
@@ -74,6 +77,8 @@ kotlin {
 
             implementation(libs.koog.agents)
             implementation(libs.koog.executor.llms.all)
+
+            implementation(libs.markdown.renderer)
         }
 
         androidMain.dependencies {
@@ -106,4 +111,25 @@ dependencies {
 
 room {
     schemaDirectory("$projectDir/schemas")
+}
+
+buildkonfig {
+    packageName = "dev.johnoreilly.common"
+
+    val localPropsFile = rootProject.file("local.properties")
+    val localProperties = Properties()
+    if (localPropsFile.exists()) {
+        runCatching {
+            localProperties.load(localPropsFile.inputStream())
+        }.getOrElse {
+            it.printStackTrace()
+        }
+    }
+    defaultConfigs {
+        buildConfigField(
+            FieldSpec.Type.STRING,
+            "GEMINI_API_KEY",
+            localProperties["gemini_api_key"]?.toString() ?: ""
+        )
+    }
 }

--- a/common/schemas/dev.johnoreilly.common.database.AppDatabase/2.json
+++ b/common/schemas/dev.johnoreilly.common.database.AppDatabase/2.json
@@ -1,0 +1,177 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "6a37186204f324f510d6ef6e3bc1bb34",
+    "entities": [
+      {
+        "tableName": "Team",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `index` INTEGER NOT NULL, `name` TEXT NOT NULL, `code` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "code",
+            "columnName": "code",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "Player",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `team` TEXT NOT NULL, `photoUrl` TEXT NOT NULL, `points` INTEGER NOT NULL, `currentPrice` REAL NOT NULL, `goalsScored` INTEGER NOT NULL, `assists` INTEGER NOT NULL, `nationality` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "team",
+            "columnName": "team",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "photoUrl",
+            "columnName": "photoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "points",
+            "columnName": "points",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currentPrice",
+            "columnName": "currentPrice",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "goalsScored",
+            "columnName": "goalsScored",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "assists",
+            "columnName": "assists",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nationality",
+            "columnName": "nationality",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "GameFixture",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `localKickoffTime` TEXT, `homeTeam` TEXT NOT NULL, `awayTeam` TEXT NOT NULL, `homeTeamPhotoUrl` TEXT NOT NULL, `awayTeamPhotoUrl` TEXT NOT NULL, `homeTeamScore` INTEGER, `awayTeamScore` INTEGER, `event` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localKickoffTime",
+            "columnName": "localKickoffTime",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "homeTeam",
+            "columnName": "homeTeam",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "awayTeam",
+            "columnName": "awayTeam",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeTeamPhotoUrl",
+            "columnName": "homeTeamPhotoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "awayTeamPhotoUrl",
+            "columnName": "awayTeamPhotoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "homeTeamScore",
+            "columnName": "homeTeamScore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "awayTeamScore",
+            "columnName": "awayTeamScore",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "event",
+            "columnName": "event",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6a37186204f324f510d6ef6e3bc1bb34')"
+    ]
+  }
+}

--- a/common/src/androidMain/kotlin/dev/johnoreilly/common/actual.kt
+++ b/common/src/androidMain/kotlin/dev/johnoreilly/common/actual.kt
@@ -24,6 +24,7 @@ fun createRoomDatabase(ctx: Context): AppDatabase {
     return Room.databaseBuilder<AppDatabase>(ctx, dbFile.absolutePath)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
+        .fallbackToDestructiveMigration(dropAllTables = true)
         .build()
 }
 

--- a/common/src/androidMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.android.kt
+++ b/common/src/androidMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.android.kt
@@ -1,12 +1,12 @@
-package dev.johnoreilly.climatetrace.agent
+package dev.johnoreilly.common.agent
 
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.prompt.llm.LLModel
+import dev.johnoreilly.common.BuildKonfig
 
 actual fun getLLModel() = GoogleModels.Gemini2_5Flash
 
-actual fun getPromptExecutor(apiKey: String): PromptExecutor {
-    return simpleGoogleAIExecutor(apiKey)
+actual fun getPromptExecutor(): PromptExecutor {
+    return simpleGoogleAIExecutor(BuildKonfig.GEMINI_API_KEY)
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/AgentProvider.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/AgentProvider.kt
@@ -1,0 +1,39 @@
+package dev.johnoreilly.common.agent
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.tools.annotations.LLMDescription
+import ai.koog.prompt.executor.model.PromptExecutor
+import ai.koog.prompt.llm.LLModel
+import kotlinx.serialization.Serializable
+
+expect fun getLLModel(): LLModel
+expect fun getPromptExecutor(): PromptExecutor
+
+/**
+ * Structured assistant answer. The model fills [playerIds] with the exact FPL ids of any
+ * players it referenced, so the UI can render player cards deterministically (no name matching).
+ */
+@Serializable
+@LLMDescription("A Fantasy Premier League assistant answer")
+data class FplAnswer(
+    @property:LLMDescription("The user-facing answer, formatted as markdown")
+    val text: String,
+    @property:LLMDescription("The FPL 'id' of every player referenced in the answer, to display as cards; empty if none")
+    val playerIds: List<Int> = emptyList(),
+    @property:LLMDescription("The 'id' of every fixture referenced in the answer, to display as cards; empty if none")
+    val fixtureIds: List<Int> = emptyList(),
+)
+
+/**
+ * Factory for the Fantasy Premier League Koog agent. The callbacks let the UI stream
+ * intermediate events (tool calls, errors) and drive a multi-turn conversation.
+ */
+interface AgentProvider {
+    val description: String
+
+    suspend fun provideAgent(
+        onToolCallEvent: suspend (String) -> Unit,
+        onErrorEvent: suspend (String) -> Unit,
+        onAssistantMessage: suspend (FplAnswer) -> String
+    ): AIAgent<String, String>
+}

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.kt
@@ -1,64 +1,48 @@
-package dev.johnoreilly.climatetrace.agent
+package dev.johnoreilly.common.agent
 
 import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.functionalStrategy
 import ai.koog.agents.core.tools.ToolRegistry
-import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.prompt.llm.LLModel
-import dev.johnoreilly.common.agent.GetFixturesTool
-import dev.johnoreilly.common.agent.GetPlayersTool
 import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
 
 
-expect fun getLLModel(): LLModel
-expect fun getPromptExecutor(apiKey: String = ""): PromptExecutor
-
+/**
+ * One-shot console agent used by the JVM `main` demo. The UI uses
+ * [FantasyPremierLeagueAgentProvider] instead (streaming, multi-turn).
+ */
 class FantasyPremierLeagueAgent(private val fantasyPremierLeagueRepository: FantasyPremierLeagueRepository) {
-    private val apiKeyGoogle = ""
 
     suspend fun createAgent() = AIAgent(
-            promptExecutor = getPromptExecutor(apiKeyGoogle),
-            llmModel = getLLModel(),
-            toolRegistry = createToolSetRegistry(fantasyPremierLeagueRepository),
-            strategy = functionalStrategy<String, String> { input ->
-                println("Calling LLM with Input = $input")
-                var response = requestLLM(input)
-
-                var toolCalls = getToolCalls(response)
-                while (toolCalls.isNotEmpty()) {
-                    println("Pending Calls")
-                    println(toolCalls.map { "${it.tool} ${it.args}" })
-                    val results = executeTools(toolCalls, parallelTools = true)
-                    response = sendToolResults(results)
-                    toolCalls = getToolCalls(response)
-                }
-
-                getTextParts(response).joinToString("") { it.text }
-            },
-        systemPrompt  =
+        promptExecutor = getPromptExecutor(),
+        llmModel = getLLModel(),
+        toolRegistry = createToolSetRegistry(fantasyPremierLeagueRepository),
+        strategy = functionalStrategy<String, String> { input ->
+            var response = requestLLM(input)
+            var toolCalls = getToolCalls(response)
+            while (toolCalls.isNotEmpty()) {
+                val results = executeTools(response)
+                response = sendToolResults(results)
+                toolCalls = getToolCalls(response)
+            }
+            getTextParts(response).joinToString("") { it.text }
+        },
+        systemPrompt =
             """
                 You an AI assistant specialising in providing information about the fantasy premier league competition.
-                The current date is October 19th 2025.
-
                 Only use the tools provided to get player and fixture data.
             """.trimIndent(),
-        )
-
-
+    )
 
     suspend fun runAgent(prompt: String): String {
         val agent = createAgent()
-        println("Running agent")
         val output = agent.run(prompt)
-        println("Result = $output")
         return output
     }
 
-    private suspend fun createToolSetRegistry(fantasyPremierLeagueRepository: FantasyPremierLeagueRepository): ToolRegistry {
-        val localToolSetRegistry = ToolRegistry {
+    private fun createToolSetRegistry(fantasyPremierLeagueRepository: FantasyPremierLeagueRepository): ToolRegistry {
+        return ToolRegistry {
             tool(GetPlayersTool(fantasyPremierLeagueRepository))
             tool(GetFixturesTool(fantasyPremierLeagueRepository))
         }
-        return localToolSetRegistry
     }
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgentProvider.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgentProvider.kt
@@ -1,0 +1,96 @@
+package dev.johnoreilly.common.agent
+
+import ai.koog.agents.core.agent.AIAgent
+import ai.koog.agents.core.agent.config.AIAgentConfig
+import ai.koog.agents.core.agent.functionalStrategy
+import ai.koog.agents.core.tools.ToolRegistry
+import ai.koog.agents.features.eventHandler.feature.EventHandler
+import ai.koog.prompt.dsl.prompt
+import ai.koog.prompt.executor.model.StructureFixingParser
+import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
+
+class FantasyPremierLeagueAgentProvider(
+    private val repository: FantasyPremierLeagueRepository
+) : AgentProvider {
+
+    override val description: String =
+        "Hi, I'm a Fantasy Premier League assistant. Ask me about players, fixtures and teams."
+
+    override suspend fun provideAgent(
+        onToolCallEvent: suspend (String) -> Unit,
+        onErrorEvent: suspend (String) -> Unit,
+        onAssistantMessage: suspend (FplAnswer) -> String,
+    ): AIAgent<String, String> {
+
+        val toolRegistry = ToolRegistry {
+            tool(GetPlayersTool(repository))
+            tool(GetFixturesTool(repository))
+            tool(GetLeagueStandingsTool(repository))
+        }
+
+        val agentConfig = AIAgentConfig(
+            prompt = prompt("fantasyPremierLeague") {
+                system(
+                    """
+                    You are an AI assistant specialising in the Fantasy Premier League competition.
+                    Only use the tools provided to get player, fixture and mini-league standings data.
+                    Keep answers concise and, where useful, present players or fixtures as a short list.
+                    """.trimIndent(),
+                )
+            },
+            model = getLLModel(),
+            maxAgentIterations = 50
+        )
+
+        return AIAgent(
+            promptExecutor = getPromptExecutor(),
+            strategy = createStrategy(onAssistantMessage),
+            agentConfig = agentConfig,
+            toolRegistry = toolRegistry,
+        ) {
+            install(EventHandler) {
+                onToolCallStarting { ctx ->
+                    onToolCallEvent("Tool ${ctx.toolName}, args ${ctx.toolArgs}")
+                }
+                onAgentExecutionFailed { ctx ->
+                    onErrorEvent("${ctx.error.message}")
+                }
+            }
+        }
+    }
+
+    /**
+     * Two-level conversation strategy: the outer loop continues while the user keeps
+     * replying (an empty reply ends the chat); the inner loop runs agentic tool calls,
+     * feeding results back to the LLM until it has an answer. The answer is then requested
+     * as structured [FplAnswer] data so the UI gets the exact player ids to render as cards.
+     */
+    private fun createStrategy(onAssistantMessage: suspend (FplAnswer) -> String) =
+        functionalStrategy<String, String> { initialInput ->
+            var inputMessage = initialInput
+            var lastText = ""
+
+            while (inputMessage.isNotEmpty()) {
+                var response = requestLLM(inputMessage)
+
+                while (getToolCalls(response).isNotEmpty()) {
+                    val results = executeTools(response)
+                    response = sendToolResults(results)
+                }
+
+                // Ask the model to express its answer as structured data (deterministic player ids)
+                val answer = requestLLMStructured<FplAnswer>(
+                    "Return your final answer as structured data. Put the FPL 'id' of every player you " +
+                        "referenced in 'playerIds' and every fixture in 'fixtureIds'. Those players/fixtures are " +
+                        "shown to the user as cards, so 'text' should be a brief markdown lead-in or summary and " +
+                        "must NOT re-list the individual players or fixtures. If there are no ids, put the full " +
+                        "answer in 'text'.",
+                    fixingParser = StructureFixingParser(getLLModel(), retries = 2),
+                ).getOrNull()?.data ?: FplAnswer(text = response.textContent())
+
+                lastText = answer.text
+                inputMessage = onAssistantMessage(answer)
+            }
+            lastText
+        }
+}

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueTool.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueTool.kt
@@ -45,3 +45,32 @@ class GetFixturesTool(val fantasyPremierLeagueRepository: FantasyPremierLeagueRe
     }
 
 }
+
+
+class GetLeagueStandingsTool(val fantasyPremierLeagueRepository: FantasyPremierLeagueRepository) : SimpleTool<Unit>(
+    argsType = typeToken<Unit>(),
+    name = "getLeagueStandings",
+    description = "Get the standings for the user's tracked mini-leagues"
+) {
+    override suspend fun execute(args: Unit): String {
+        try {
+            val leagueIds = fantasyPremierLeagueRepository.leagues.first()
+            if (leagueIds.isEmpty()) {
+                return "The user is not tracking any mini-leagues."
+            }
+            return leagueIds.mapNotNull { leagueId ->
+                runCatching {
+                    val standings = fantasyPremierLeagueRepository.getLeagueStandings(leagueId.trim().toInt())
+                    val rows = standings.standings.results.joinToString("\n") { result ->
+                        "${result.rank}. ${result.entryName} (${result.playerName}) - ${result.total} pts"
+                    }
+                    "League '${standings.league.name}':\n$rows"
+                }.getOrNull()
+            }.joinToString("\n\n").ifEmpty { "No league standings available." }
+        } catch (e: Exception) {
+            println("Error: $e")
+            return ""
+        }
+    }
+
+}

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/ElementDto.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/ElementDto.kt
@@ -70,5 +70,6 @@ data class ElementDto(
     val value_form: String,
     val value_season: String,
     val web_name: String,
-    val yellow_cards: Int
+    val yellow_cards: Int,
+    val region: Int? = null
 )

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/RegionDto.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/RegionDto.kt
@@ -1,0 +1,12 @@
+package dev.johnoreilly.common.data.model
+
+import kotlinx.serialization.Serializable
+
+/** An entry from the FPL /api/regions/ endpoint (player nationality lookup). */
+@Serializable
+data class RegionDto(
+    val id: Int,
+    val name: String,
+    val iso_code_short: String? = null,
+    val iso_code_long: String? = null,
+)

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/TeamDto.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/TeamDto.kt
@@ -15,7 +15,7 @@ data class TeamDto(
     val position: Int,
     val pulse_id: Int,
     val short_name: String,
-    val strength: Int,
+    val strength: Int?,
     val strength_attack_away: Int,
     val strength_attack_home: Int,
     val strength_defence_away: Int,

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/remote/FantasyPremierLeagueApi.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/remote/FantasyPremierLeagueApi.kt
@@ -6,6 +6,7 @@ import dev.johnoreilly.common.data.model.EventStatusListDto
 import dev.johnoreilly.common.data.model.FixtureDto
 import dev.johnoreilly.common.data.model.GameWeekLiveDataDto
 import dev.johnoreilly.common.data.model.LeagueStandingsDto
+import dev.johnoreilly.common.data.model.RegionDto
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
@@ -22,6 +23,7 @@ class FantasyPremierLeagueApi(
     }
 
     suspend fun fetchBootstrapStaticInfo() = fetchData<BootstrapStaticInfoDto>("bootstrap-static/")
+    suspend fun fetchRegions() = fetchData<List<RegionDto>>("regions/")
     suspend fun fetchFixtures() = fetchData<List<FixtureDto>>("fixtures")
     suspend fun fetchUpcomingFixtures() = fetchData<List<FixtureDto>>("fixtures?future=1")
     suspend fun fetchGameWeekLiveData(eventId: Int) = fetchData<GameWeekLiveDataDto>("event/$eventId/live/")

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
@@ -47,7 +47,12 @@ class FantasyPremierLeagueRepository : KoinComponent {
         try {
             val bootstrapStaticInfoDto = fantasyPremierLeagueApi.fetchBootstrapStaticInfo()
             val fixtures = fantasyPremierLeagueApi.fetchFixtures()
-            writeDataToDb(bootstrapStaticInfoDto, fixtures)
+            // region -> country name, used to populate player nationality (best-effort)
+            // region -> country name, used to populate player nationality (best-effort)
+            val regionNames = runCatching { fantasyPremierLeagueApi.fetchRegions() }
+                .getOrDefault(emptyList())
+                .associate { it.id to it.name }
+            writeDataToDb(bootstrapStaticInfoDto, fixtures, regionNames)
         } catch (e: Exception) {
             // TODO surface this to UI/option to retry etc ?
             //println("Exception reading data: $e")
@@ -58,7 +63,8 @@ class FantasyPremierLeagueRepository : KoinComponent {
     @OptIn(ExperimentalTime::class)
     private suspend fun writeDataToDb(
         bootstrapStaticInfoDto: BootstrapStaticInfoDto,
-        fixtures: List<FixtureDto>
+        fixtures: List<FixtureDto>,
+        regionNames: Map<Int, String>
     ) {
         //store current gameweek
         _currentGameweek.value =
@@ -86,7 +92,8 @@ class FantasyPremierLeagueRepository : KoinComponent {
                 playerDto.total_points,
                 currentPrice,
                 playerDto.goals_scored,
-                playerDto.assists
+                playerDto.assists,
+                playerDto.region?.let { regionNames[it] }
             )
         }
         database.fantasyPremierLeagueDao().insertPlayerList(playerList)

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/database/AppDatabase.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/database/AppDatabase.kt
@@ -13,7 +13,7 @@ import kotlinx.datetime.LocalDateTime
 
 internal expect object AppDatabaseCtor : RoomDatabaseConstructor<AppDatabase>
 
-@Database(entities = [Team::class, Player::class, GameFixture::class], version = 1)
+@Database(entities = [Team::class, Player::class, GameFixture::class], version = 2)
 @ConstructedBy(AppDatabaseCtor::class)
 @TypeConverters(LocalDateTimeConverter::class)
 abstract class AppDatabase : RoomDatabase() {

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/di/Koin.kt
@@ -1,6 +1,8 @@
 package dev.johnoreilly.common.di
 
 import dev.johnoreilly.common.AppSettings
+import dev.johnoreilly.common.agent.AgentProvider
+import dev.johnoreilly.common.agent.FantasyPremierLeagueAgentProvider
 import dev.johnoreilly.common.data.remote.FantasyPremierLeagueApi
 import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
 import dev.johnoreilly.common.platformModule
@@ -34,6 +36,8 @@ fun commonModule(enableNetworkLogs: Boolean) = module {
     single { FantasyPremierLeagueApi(get()) }
 
     single { AppSettings(get()) }
+
+    single<AgentProvider> { FantasyPremierLeagueAgentProvider(get()) }
 
     includes(viewModelModule)
     includes(platformModule())

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/di/ViewModelModule.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/di/ViewModelModule.kt
@@ -1,5 +1,6 @@
 package dev.johnoreilly.common.di
 
+import dev.johnoreilly.common.viewmodel.AgentViewModel
 import dev.johnoreilly.common.viewmodel.FixturesViewModel
 import dev.johnoreilly.common.viewmodel.LeaguesViewModel
 import dev.johnoreilly.common.viewmodel.PlayerDetailsViewModel
@@ -13,4 +14,5 @@ val viewModelModule = module {
     viewModelOf(::PlayerDetailsViewModel)
     viewModelOf(::FixturesViewModel)
     viewModelOf(::LeaguesViewModel)
+    viewModelOf(::AgentViewModel)
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/model/Player.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/model/Player.kt
@@ -13,5 +13,6 @@ data class Player(
     val points: Int,
     val currentPrice: Double,
     val goalsScored: Int,
-    val assists: Int
+    val assists: Int,
+    val nationality: String? = null
 )

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Face
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -24,6 +25,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer
+import dev.johnoreilly.common.ui.agent.AgentScreen
 import dev.johnoreilly.common.ui.fixtures.FixturesListView
 import dev.johnoreilly.common.ui.leagues.LeagueListView
 import dev.johnoreilly.common.ui.players.PlayerListView
@@ -66,9 +68,15 @@ private data object League : TopLevelRoute {
 }
 
 @Serializable
+private data object Assistant : TopLevelRoute {
+    override val icon = Icons.Filled.Face
+    override val contentDescription = "Assistant"
+}
+
+@Serializable
 private data object Settings : Route
 
-private val topLevelRoutes: List<TopLevelRoute> = listOf(PlayerList, FixtureList, League)
+private val topLevelRoutes: List<TopLevelRoute> = listOf(PlayerList, FixtureList, League, Assistant)
 
 
 @Composable
@@ -115,6 +123,7 @@ fun App() {
                     }
                     entry<FixtureList> { FixturesListView() }
                     entry<League> { LeagueListView() }
+                    entry<Assistant> { AgentScreen() }
                     entry<Settings> { SettingsView { backStack.removeLastOrNull() } }
                 },
             )

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
@@ -123,7 +123,9 @@ fun App() {
                     }
                     entry<FixtureList> { FixturesListView() }
                     entry<League> { LeagueListView() }
-                    entry<Assistant> { AgentScreen() }
+                    entry<Assistant> {
+                        AgentScreen(onPlayerSelected = { playerId -> backStack.add(PlayerDetails(playerId)) })
+                    }
                     entry<Settings> { SettingsView { backStack.removeLastOrNull() } }
                 },
             )

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/App.kt
@@ -55,6 +55,11 @@ private data object PlayerList : TopLevelRoute {
 @Serializable
 private data class PlayerDetails(val playerId: Int) : Route
 
+// Full-screen player details reached from the assistant (not a list-detail pane),
+// so it opens as a dedicated screen you can navigate back from.
+@Serializable
+private data class AssistantPlayerDetails(val playerId: Int) : Route
+
 @Serializable
 private data object FixtureList : TopLevelRoute {
     override val icon = Icons.Filled.DateRange
@@ -124,7 +129,15 @@ fun App() {
                     entry<FixtureList> { FixturesListView() }
                     entry<League> { LeagueListView() }
                     entry<Assistant> {
-                        AgentScreen(onPlayerSelected = { playerId -> backStack.add(PlayerDetails(playerId)) })
+                        AgentScreen(onPlayerSelected = { playerId -> backStack.add(AssistantPlayerDetails(playerId)) })
+                    }
+                    entry<AssistantPlayerDetails> { key ->
+                        val viewModel = koinViewModel<PlayerDetailsViewModel>(
+                            parameters = { parametersOf(key.playerId) }
+                        )
+                        PlayerDetailsView(
+                            viewModel,
+                            popBackStack = { backStack.removeLastOrNull() })
                     }
                     entry<Settings> { SettingsView { backStack.removeLastOrNull() } }
                 },

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
@@ -1,0 +1,339 @@
+package dev.johnoreilly.common.ui.agent
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.ElevatedCard
+import com.mikepenz.markdown.m3.Markdown
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
+import dev.johnoreilly.common.model.GameFixture
+import dev.johnoreilly.common.model.Player
+import dev.johnoreilly.common.ui.fixtures.ClubInFixtureView
+import dev.johnoreilly.common.ui.players.PlayerView
+import dev.johnoreilly.common.viewmodel.AgentViewModel
+import dev.johnoreilly.common.viewmodel.Message
+import org.koin.compose.viewmodel.koinViewModel
+
+private val suggestions = listOf(
+    "Who are the top scoring players?",
+    "What are the next fixtures?",
+    "Best value midfielders?",
+)
+
+@Composable
+fun AgentScreen() {
+    val viewModel = koinViewModel<AgentViewModel>()
+    val uiState by viewModel.uiState.collectAsState()
+
+    AgentScreenContent(
+        messages = uiState.messages,
+        inputText = uiState.inputText,
+        isInputEnabled = uiState.isInputEnabled,
+        isLoading = uiState.isLoading,
+        isChatEnded = uiState.isChatEnded,
+        onInputTextChanged = viewModel::updateInputText,
+        onSendClicked = viewModel::sendMessage,
+        onRestartClicked = viewModel::restartChat,
+        onSuggestionClicked = {
+            viewModel.updateInputText(it)
+            viewModel.sendMessage()
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AgentScreenContent(
+    messages: List<Message>,
+    inputText: String,
+    isInputEnabled: Boolean,
+    isLoading: Boolean,
+    isChatEnded: Boolean,
+    onInputTextChanged: (String) -> Unit,
+    onSendClicked: () -> Unit,
+    onRestartClicked: () -> Unit,
+    onSuggestionClicked: (String) -> Unit,
+) {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(messages.size) {
+        if (messages.isNotEmpty()) listState.animateScrollToItem(messages.size - 1)
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("FPL Assistant") },
+                actions = {
+                    IconButton(onClick = onRestartClicked) {
+                        Icon(Icons.Filled.Refresh, contentDescription = "Restart chat")
+                    }
+                }
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .imePadding()
+        ) {
+            LazyColumn(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp),
+                state = listState,
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(messages) { message ->
+                    when (message) {
+                        is Message.UserMessage -> UserMessageBubble(message.text)
+                        is Message.AgentMessage -> AgentMessageBubble(message.text, message.players, message.fixtures)
+                        is Message.SystemMessage -> SystemMessageItem(message.text)
+                        is Message.ErrorMessage -> LabelledBubble("Error", message.text, MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer)
+                        is Message.ToolCallMessage -> LabelledBubble("Tool call", message.text, MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer)
+                        is Message.ResultMessage -> LabelledBubble("Result", message.text, MaterialTheme.colorScheme.secondary, MaterialTheme.colorScheme.secondaryContainer, MaterialTheme.colorScheme.onSecondaryContainer)
+                    }
+                }
+                if (isLoading) item { AgentMessageBubble("…") }
+                item { Spacer(Modifier.height(8.dp)) }
+            }
+
+            // Suggestion chips (only before the chat has started)
+            if (messages.count { it is Message.UserMessage } == 0) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(rememberScrollState())
+                        .padding(horizontal = 12.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    suggestions.forEach { s ->
+                        AssistChip(onClick = { onSuggestionClicked(s) }, label = { Text(s) })
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+
+            InputArea(
+                text = inputText,
+                onTextChanged = onInputTextChanged,
+                onSendClicked = onSendClicked,
+                isEnabled = isInputEnabled && !isChatEnded,
+                isLoading = isLoading,
+            )
+        }
+    }
+}
+
+@Composable
+private fun UserMessageBubble(text: String) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+        Box(
+            modifier = Modifier
+                .widthIn(max = 300.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.primary)
+                .padding(12.dp)
+        ) {
+            Text(text, color = MaterialTheme.colorScheme.onPrimary, style = MaterialTheme.typography.bodyLarge)
+        }
+        Spacer(Modifier.width(8.dp))
+        Avatar(isUser = true)
+    }
+}
+
+@Composable
+private fun AgentMessageBubble(
+    text: String,
+    players: List<Player> = emptyList(),
+    fixtures: List<GameFixture> = emptyList(),
+) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+        Avatar(isUser = false)
+        Spacer(Modifier.width(8.dp))
+        Column(Modifier.widthIn(max = 320.dp)) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.primaryContainer)
+                    .padding(12.dp)
+            ) {
+                Markdown(
+                    content = text,
+                    colors = markdownColor(text = MaterialTheme.colorScheme.onPrimaryContainer),
+                    typography = markdownTypography(text = MaterialTheme.typography.bodyLarge)
+                )
+            }
+            // Rich cards for any players/fixtures the answer referenced
+            if (players.isNotEmpty() || fixtures.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                ElevatedCard {
+                    Column {
+                        players.forEach { player ->
+                            PlayerView(player = player, onPlayerSelected = {}, isDataLoading = false)
+                        }
+                        fixtures.forEach { fixture -> FixtureCard(fixture) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun FixtureCard(fixture: GameFixture) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            ClubInFixtureView(teamName = fixture.homeTeam, teamPhotoUrl = fixture.homeTeamPhotoUrl)
+        }
+        val middle = if (fixture.homeTeamScore != null && fixture.awayTeamScore != null) {
+            "${fixture.homeTeamScore} - ${fixture.awayTeamScore}"
+        } else {
+            fixture.localKickoffTime?.date?.toString() ?: "v"
+        }
+        Text(
+            text = middle,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+            ClubInFixtureView(teamName = fixture.awayTeam, teamPhotoUrl = fixture.awayTeamPhotoUrl)
+        }
+    }
+}
+
+@Composable
+private fun Avatar(isUser: Boolean) {
+    val bg = if (isUser) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.primaryContainer
+    val fg = if (isUser) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onPrimaryContainer
+    Box(Modifier.size(32.dp).clip(CircleShape).background(bg), contentAlignment = Alignment.Center) {
+        Text(if (isUser) "U" else "A", color = fg, style = MaterialTheme.typography.labelMedium)
+    }
+}
+
+@Composable
+private fun SystemMessageItem(text: String) {
+    Box(Modifier.fillMaxWidth().padding(vertical = 8.dp), contentAlignment = Alignment.Center) {
+        Text(text, color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@Composable
+private fun LabelledBubble(
+    label: String,
+    text: String,
+    labelColor: androidx.compose.ui.graphics.Color,
+    container: androidx.compose.ui.graphics.Color,
+    onContainer: androidx.compose.ui.graphics.Color,
+) {
+    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
+        Column(Modifier.widthIn(max = 300.dp)) {
+            Text(label, color = labelColor, style = MaterialTheme.typography.labelMedium, modifier = Modifier.padding(start = 8.dp))
+            Box(Modifier.clip(RoundedCornerShape(16.dp)).background(container).padding(12.dp)) {
+                Text(text, color = onContainer, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun InputArea(
+    text: String,
+    onTextChanged: (String) -> Unit,
+    onSendClicked: () -> Unit,
+    isEnabled: Boolean,
+    isLoading: Boolean,
+) {
+    Surface(Modifier.fillMaxWidth()) {
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            OutlinedTextField(
+                value = text,
+                onValueChange = onTextChanged,
+                modifier = Modifier.weight(1f),
+                placeholder = { Text("Ask about players or fixtures…") },
+                enabled = isEnabled,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                keyboardActions = KeyboardActions(onSend = { onSendClicked() }),
+                singleLine = true,
+                shape = RoundedCornerShape(24.dp)
+            )
+            Spacer(Modifier.width(8.dp))
+            if (isLoading) {
+                CircularProgressIndicator(Modifier.size(40.dp).padding(8.dp))
+            } else {
+                IconButton(
+                    onClick = onSendClicked,
+                    enabled = isEnabled && text.isNotBlank(),
+                    modifier = Modifier
+                        .size(40.dp)
+                        .clip(CircleShape)
+                        .background(
+                            if (isEnabled && text.isNotBlank()) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.surfaceVariant
+                        )
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.Send,
+                        contentDescription = "Send",
+                        tint = if (isEnabled && text.isNotBlank()) MaterialTheme.colorScheme.onPrimary
+                        else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
@@ -65,7 +65,7 @@ private val suggestions = listOf(
 )
 
 @Composable
-fun AgentScreen() {
+fun AgentScreen(onPlayerSelected: (playerId: Int) -> Unit = {}) {
     val viewModel = koinViewModel<AgentViewModel>()
     val uiState by viewModel.uiState.collectAsState()
 
@@ -81,7 +81,8 @@ fun AgentScreen() {
         onSuggestionClicked = {
             viewModel.updateInputText(it)
             viewModel.sendMessage()
-        }
+        },
+        onPlayerSelected = onPlayerSelected,
     )
 }
 
@@ -97,6 +98,7 @@ private fun AgentScreenContent(
     onSendClicked: () -> Unit,
     onRestartClicked: () -> Unit,
     onSuggestionClicked: (String) -> Unit,
+    onPlayerSelected: (playerId: Int) -> Unit,
 ) {
     val listState = rememberLazyListState()
 
@@ -134,7 +136,7 @@ private fun AgentScreenContent(
                 items(messages) { message ->
                     when (message) {
                         is Message.UserMessage -> UserMessageBubble(message.text)
-                        is Message.AgentMessage -> AgentMessageBubble(message.text, message.players, message.fixtures)
+                        is Message.AgentMessage -> AgentMessageBubble(message.text, message.players, message.fixtures, onPlayerSelected)
                         is Message.SystemMessage -> SystemMessageItem(message.text)
                         is Message.ErrorMessage -> LabelledBubble("Error", message.text, MaterialTheme.colorScheme.error, MaterialTheme.colorScheme.errorContainer, MaterialTheme.colorScheme.onErrorContainer)
                         is Message.ToolCallMessage -> LabelledBubble("Tool call", message.text, MaterialTheme.colorScheme.tertiary, MaterialTheme.colorScheme.tertiaryContainer, MaterialTheme.colorScheme.onTertiaryContainer)
@@ -194,6 +196,7 @@ private fun AgentMessageBubble(
     text: String,
     players: List<Player> = emptyList(),
     fixtures: List<GameFixture> = emptyList(),
+    onPlayerSelected: (playerId: Int) -> Unit = {},
 ) {
     Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Start) {
         Avatar(isUser = false)
@@ -217,7 +220,7 @@ private fun AgentMessageBubble(
                 ElevatedCard {
                     Column {
                         players.forEach { player ->
-                            PlayerView(player = player, onPlayerSelected = {}, isDataLoading = false)
+                            PlayerView(player = player, onPlayerSelected = { onPlayerSelected(it.id) }, isDataLoading = false)
                         }
                         fixtures.forEach { fixture -> FixtureCard(fixture) }
                     }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/agent/AgentScreen.kt
@@ -232,26 +232,40 @@ private fun AgentMessageBubble(
 
 @Composable
 private fun FixtureCard(fixture: GameFixture) {
-    Row(
+    Column(
         modifier = Modifier.fillMaxWidth().padding(12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceEvenly,
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
-            ClubInFixtureView(teamName = fixture.homeTeam, teamPhotoUrl = fixture.homeTeamPhotoUrl)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                ClubInFixtureView(teamName = fixture.homeTeam, teamPhotoUrl = fixture.homeTeamPhotoUrl)
+            }
+            val score = if (fixture.homeTeamScore != null && fixture.awayTeamScore != null) {
+                "${fixture.homeTeamScore} - ${fixture.awayTeamScore}"
+            } else {
+                "v"
+            }
+            Text(
+                text = score,
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
+                ClubInFixtureView(teamName = fixture.awayTeam, teamPhotoUrl = fixture.awayTeamPhotoUrl)
+            }
         }
-        val middle = if (fixture.homeTeamScore != null && fixture.awayTeamScore != null) {
-            "${fixture.homeTeamScore} - ${fixture.awayTeamScore}"
-        } else {
-            fixture.localKickoffTime?.date?.toString() ?: "v"
-        }
-        Text(
-            text = middle,
-            style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Box(Modifier.weight(1f), contentAlignment = Alignment.Center) {
-            ClubInFixtureView(teamName = fixture.awayTeam, teamPhotoUrl = fixture.awayTeamPhotoUrl)
+        fixture.localKickoffTime?.let { kickoff ->
+            val time = "${kickoff.hour.toString().padStart(2, '0')}:${kickoff.minute.toString().padStart(2, '0')}"
+            Text(
+                text = "${kickoff.date} $time",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp),
+            )
         }
     }
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/AgentViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/AgentViewModel.kt
@@ -1,0 +1,181 @@
+package dev.johnoreilly.common.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.johnoreilly.common.agent.AgentProvider
+import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
+import dev.johnoreilly.common.model.GameFixture
+import dev.johnoreilly.common.model.Player
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// Chat message types
+sealed class Message {
+    data class UserMessage(val text: String) : Message()
+    // An agent answer, optionally enriched with players/fixtures it referenced (rendered as cards)
+    data class AgentMessage(
+        val text: String,
+        val players: List<Player> = emptyList(),
+        val fixtures: List<GameFixture> = emptyList(),
+    ) : Message()
+    data class SystemMessage(val text: String) : Message()
+    data class ErrorMessage(val text: String) : Message()
+    data class ToolCallMessage(val text: String) : Message()
+    data class ResultMessage(val text: String) : Message()
+}
+
+data class AgentUiState(
+    val messages: List<Message> = emptyList(),
+    val inputText: String = "Who are the top scoring players?",
+    val isInputEnabled: Boolean = true,
+    val isLoading: Boolean = false,
+    val isChatEnded: Boolean = false,
+
+    // For handling user responses when the agent asks a follow-up question
+    val userResponseRequested: Boolean = false,
+    val currentUserResponse: String? = null,
+)
+
+class AgentViewModel(
+    private val agentProvider: AgentProvider,
+    private val repository: FantasyPremierLeagueRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        AgentUiState(messages = listOf(Message.SystemMessage(agentProvider.description)))
+    )
+    val uiState: StateFlow<AgentUiState> = _uiState.asStateFlow()
+
+    // Cached lists, used to resolve the ids the agent returns into cards
+    private var players: List<Player>? = null
+    private var fixtures: List<GameFixture>? = null
+
+    /** Resolve the agent-provided player [ids] to players, preserving the agent's order. */
+    private suspend fun playersByIds(ids: List<Int>): List<Player> {
+        if (ids.isEmpty()) return emptyList()
+        val all = players ?: runCatching { repository.getPlayers().first() }.getOrNull().orEmpty()
+            .also { players = it }
+        val byId = all.associateBy { it.id }
+        return ids.mapNotNull { byId[it] }
+    }
+
+    /** Resolve the agent-provided fixture [ids] to fixtures, preserving the agent's order. */
+    private suspend fun fixturesByIds(ids: List<Int>): List<GameFixture> {
+        if (ids.isEmpty()) return emptyList()
+        val all = fixtures ?: runCatching { repository.getFixtures().first() }.getOrNull().orEmpty()
+            .also { fixtures = it }
+        val byId = all.associateBy { it.id }
+        return ids.mapNotNull { byId[it] }
+    }
+
+    fun updateInputText(text: String) {
+        _uiState.update { it.copy(inputText = text) }
+    }
+
+    fun sendMessage() {
+        val userInput = _uiState.value.inputText.trim()
+        if (userInput.isEmpty()) return
+
+        if (_uiState.value.userResponseRequested) {
+            // Deliver the reply to a suspended agent question
+            _uiState.update {
+                it.copy(
+                    messages = it.messages + Message.UserMessage(userInput),
+                    inputText = "",
+                    isLoading = true,
+                    userResponseRequested = false,
+                    currentUserResponse = userInput
+                )
+            }
+        } else {
+            // First message — kick off the agent
+            _uiState.update {
+                it.copy(
+                    messages = it.messages + Message.UserMessage(userInput),
+                    inputText = "",
+                    isInputEnabled = false,
+                    isLoading = true
+                )
+            }
+            viewModelScope.launch { runAgent(userInput) }
+        }
+    }
+
+    private suspend fun runAgent(userInput: String) {
+        withContext(Dispatchers.Default) {
+            try {
+                val agent = agentProvider.provideAgent(
+                    onToolCallEvent = { message ->
+                        viewModelScope.launch {
+                            _uiState.update { it.copy(messages = it.messages + Message.ToolCallMessage(message)) }
+                        }
+                    },
+                    onErrorEvent = { errorMessage ->
+                        viewModelScope.launch {
+                            _uiState.update {
+                                it.copy(
+                                    messages = it.messages + Message.ErrorMessage(errorMessage),
+                                    isInputEnabled = true,
+                                    isLoading = false
+                                )
+                            }
+                        }
+                    },
+                    onAssistantMessage = { answer ->
+                        val playerCards = playersByIds(answer.playerIds)
+                        val fixtureCards = fixturesByIds(answer.fixtureIds)
+                        _uiState.update {
+                            it.copy(
+                                messages = it.messages + Message.AgentMessage(answer.text, playerCards, fixtureCards),
+                                isInputEnabled = true,
+                                isLoading = false,
+                                userResponseRequested = true
+                            )
+                        }
+
+                        val userResponse = _uiState
+                            .first { it.currentUserResponse != null }
+                            .currentUserResponse
+                            ?: throw IllegalArgumentException("User response is null")
+
+                        _uiState.update { it.copy(currentUserResponse = null) }
+                        userResponse
+                    },
+                )
+
+                val result = agent.run(userInput)
+
+                _uiState.update {
+                    it.copy(
+                        messages = it.messages +
+                                Message.ResultMessage(result) +
+                                Message.SystemMessage("The agent has stopped."),
+                        isInputEnabled = false,
+                        isLoading = false,
+                        isChatEnded = true
+                    )
+                }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        messages = it.messages + Message.ErrorMessage("Error: ${e.message}"),
+                        isInputEnabled = true,
+                        isLoading = false
+                    )
+                }
+            }
+        }
+    }
+
+    fun restartChat() {
+        _uiState.update {
+            AgentUiState(messages = listOf(Message.SystemMessage(agentProvider.description)))
+        }
+    }
+}

--- a/common/src/iOSMain/kotlin/dev/johnoreilly/common/actual.kt
+++ b/common/src/iOSMain/kotlin/dev/johnoreilly/common/actual.kt
@@ -29,6 +29,7 @@ fun createRoomDatabase(): AppDatabase {
     return Room.databaseBuilder<AppDatabase>(name = dbFile)
         .setDriver(BundledSQLiteDriver())
         .setQueryCoroutineContext(Dispatchers.IO)
+        .fallbackToDestructiveMigration(dropAllTables = true)
         .build()
 }
 

--- a/common/src/iOSMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.ios.kt
+++ b/common/src/iOSMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.ios.kt
@@ -1,12 +1,13 @@
-package dev.johnoreilly.climatetrace.agent
+package dev.johnoreilly.common.agent
 
 import ai.koog.http.client.ktor.KtorKoogHttpClient
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
+import dev.johnoreilly.common.BuildKonfig
 
 actual fun getLLModel() = GoogleModels.Gemini2_5Flash
 
-actual fun getPromptExecutor(apiKey: String): PromptExecutor {
-    return simpleGoogleAIExecutor(apiKey, KtorKoogHttpClient.Factory())
+actual fun getPromptExecutor(): PromptExecutor {
+    return simpleGoogleAIExecutor(BuildKonfig.GEMINI_API_KEY, KtorKoogHttpClient.Factory())
 }

--- a/common/src/jvmMain/kotlin/dev/johnoreilly/common/Main.kt
+++ b/common/src/jvmMain/kotlin/dev/johnoreilly/common/Main.kt
@@ -1,6 +1,6 @@
 package dev.johnoreilly.common
 
-import dev.johnoreilly.climatetrace.agent.FantasyPremierLeagueAgent
+import dev.johnoreilly.common.agent.FantasyPremierLeagueAgent
 import dev.johnoreilly.common.data.model.BootstrapStaticInfoDto
 import dev.johnoreilly.common.data.remote.FantasyPremierLeagueApi
 import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository

--- a/common/src/jvmMain/kotlin/dev/johnoreilly/common/actual.kt
+++ b/common/src/jvmMain/kotlin/dev/johnoreilly/common/actual.kt
@@ -21,6 +21,7 @@ fun createRoomDatabase(): AppDatabase {
     val dbFile = File(System.getProperty("java.io.tmpdir"), dbFileName)
     return Room.databaseBuilder<AppDatabase>(name = dbFile.absolutePath,)
         .setDriver(BundledSQLiteDriver())
+        .fallbackToDestructiveMigration(dropAllTables = true)
         .build()
 }
 

--- a/common/src/jvmMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.jvm.kt
+++ b/common/src/jvmMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueAgent.jvm.kt
@@ -1,32 +1,12 @@
-package dev.johnoreilly.climatetrace.agent
+package dev.johnoreilly.common.agent
 
 import ai.koog.prompt.executor.clients.google.GoogleModels
 import ai.koog.prompt.executor.llms.all.simpleGoogleAIExecutor
-import ai.koog.prompt.executor.llms.all.simpleOllamaAIExecutor
 import ai.koog.prompt.executor.model.PromptExecutor
-import ai.koog.prompt.llm.LLMCapability
-import ai.koog.prompt.llm.LLMProvider
-import ai.koog.prompt.llm.LLModel
-
-//actual fun getLLModel(): LLModel {
-//    return LLModel(
-//        provider = LLMProvider.Ollama,
-//        id = "gpt-oss:20b",
-//        capabilities = listOf(
-//            LLMCapability.Temperature,
-//            LLMCapability.Schema.JSON.Standard,
-//            LLMCapability.Tools
-//        ),
-//        contextLength = 128_000,
-//    )
-//}
-//
-//actual fun getPromptExecutor(apiKey: String): PromptExecutor {
-//    return simpleOllamaAIExecutor()
-//}
+import dev.johnoreilly.common.BuildKonfig
 
 actual fun getLLModel() = GoogleModels.Gemini2_5Pro
 
-actual fun getPromptExecutor(apiKey: String): PromptExecutor {
-    return simpleGoogleAIExecutor(apiKey)
+actual fun getPromptExecutor(): PromptExecutor {
+    return simpleGoogleAIExecutor(BuildKonfig.GEMINI_API_KEY)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,8 @@ kotlinStatistics = "1.2.1"
 mcp = "0.14.0"
 koogAgents = "1.1.1"
 koogExecutors = "1.1.1-beta"
+buildkonfig = "0.22.0"
+markdownRenderer = "0.43.0"
 shadowPlugin = "9.6.1"
 
 
@@ -85,6 +87,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 mcp-kotlin = { group = "io.modelcontextprotocol", name = "kotlin-sdk", version.ref = "mcp" }
 koog-agents = { module = "ai.koog:koog-agents", version.ref = "koogAgents" }
+markdown-renderer = { module = "com.mikepenz:multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 koog-executor-llms-all = { module = "ai.koog:prompt-executor-llms-all", version.ref = "koogExecutors" }
 
 
@@ -101,4 +104,5 @@ room = { id = "androidx.room", version.ref = "androidxRoom" }
 jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm" }
+buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }
 shadowPlugin = { id = "com.gradleup.shadow", version.ref = "shadowPlugin" }


### PR DESCRIPTION
## Summary
Adds an in-app AI assistant to Fantasy Premier League, following the ClimateTraceKMP pattern. The Koog agent (with `getPlayers`/`getFixtures`/`getLeagueStandings` tools) is surfaced in the UI behind a new **Assistant** bottom-nav tab.

- **Agent** — `AgentProvider` + `FantasyPremierLeagueAgentProvider` stream tool-call/error events and drive a multi-turn conversation (Koog `EventHandler` + `functionalStrategy`).
- **Structured output (deterministic cards)** — the agent returns a typed `FplAnswer { text, playerIds, fixtureIds }` via `requestLLMStructured` (+ `StructureFixingParser`). The tools expose each entity's `id`, so the UI resolves exact ids → cards with no name-matching heuristics. `text` is a short lead-in; the cards carry the detail.
- **UI** — `AgentViewModel` (StateFlow chat state) + `Message` model, and an `AgentScreen`: markdown bubbles (`multiplatform-markdown-renderer-m3`), player cards (reusing `PlayerView`), fixture cards (reusing `ClubInFixtureView`), and suggestion chips.
- **API key** — wired via **BuildKonfig** (`gemini_api_key` from `local.properties`); `getPromptExecutor()` is now no-arg and reads `BuildKonfig.GEMINI_API_KEY` on all platforms.
- **Cleanup** — moved the agent `expect`/`actual`s out of the leftover `dev.johnoreilly.climatetrace.agent` package into `dev.johnoreilly.common.agent`.

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew test`
- [x] `./gradlew :common:compileKotlinIosSimulatorArm64`
- [x] Ran the desktop app: opened the **Assistant** tab; a players query and a fixtures query each return a markdown lead-in plus the correct player/fixture cards (driven by the model's structured ids).

> Requires `gemini_api_key=<key>` in `local.properties` (git-ignored) for the assistant to authenticate; the rest of the app is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)