### PR TITLE
Make the Renovate AGP hold actually match

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,10 @@
   ],
   "packageRules": [
     {
-      "description": "AGP 9.3.x+ outruns what the locally installed Android Studio supports — sync fails with unsupported-AGP-version and \"could not find compile target\" errors. Hold AGP updates until Studio's bundled support catches up.",
-      "matchPackageNames": [
-        "agp",
+      "description": "AGP 9.3.x+ outruns what the locally installed Android Studio supports — sync fails with unsupported-AGP-version and \"could not find compile target\" errors. Hold AGP updates until Studio's bundled support catches up. Matched on depName with an unanchored prefix: Renovate names a Gradle plugin com.android.application:com.android.application.gradle.plugin, so the previous $-anchored matchPackageNames pattern never matched and AGP PRs kept being opened.",
+      "matchDepNames": [
         "com.android.tools.build:gradle",
-        "/^com\\.android\\.(application|library|test|dynamic-feature|kotlin\\.multiplatform\\.library|lint)$/"
+        "/^com\\.android\\./"
       ],
       "enabled": false
     }


### PR DESCRIPTION
## Summary

The AGP hold added in 80fd21b has never worked — #398 bumped AGP to 9.4.0 on 24 Aug, sixteen days after the rule landed on 8 Aug.

`matchPackageNames` compares against Renovate's *packageName*, and for a Gradle plugin that's `com.android.application:com.android.application.gradle.plugin`. The `$`-anchored regex was written for the bare plugin id, so it matched nothing.

Switches to `matchDepNames` with an unanchored prefix, which covers both forms. The catalog's only `com.android.*` entries are the two AGP plugins (`com.android.application`, `com.android.kotlin.multiplatform.library`), both on the `androidGradlePlugin` version, so nothing unrelated is caught.

Note this stops Renovate *recreating* AGP PRs; the existing #398 still needs closing by hand.

## Test plan

- [x] `renovate-config-validator` reports "Config validated successfully"
- [x] Confirmed the only `com.android.*` entries in `libs.versions.toml` are the two AGP plugins, so the prefix match has no collateral
- [ ] Real confirmation is the next Renovate run not reopening an AGP PR

Left alone deliberately: the validator also flags `config:base` as needing migration to `config:recommended`. That changes which updates Renovate proposes, so it belongs in its own change rather than riding along here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gQFnBGPvUS7UoS4gdEHqn