### PR TITLE
Discover a manager's leagues from their team id, and fix blank league standings

### DIFF
--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/AppSettings.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/AppSettings.kt
@@ -20,24 +20,24 @@ fun createDataStore(
 
 class AppSettings(private val dataStore: DataStore<Preferences>) {
 
-    val leagues: Flow<List<String>> =
-        dataStore.data
-            .map { preferences ->
-                getLeaguesSettingFromString(preferences[LEAGUES_SETTING])
-            }
+    /**
+     * The manager's own entry id. Their leagues are read from it, rather than being typed in one
+     * league id at a time - `entry/{id}/` already knows every league they're in.
+     */
+    val entryId: Flow<Int?> =
+        dataStore.data.map { preferences -> preferences[ENTRY_ID_SETTING]?.toIntOrNull() }
 
-
-    suspend fun updatesLeaguesSetting(leagues: List<String>) {
+    suspend fun updateEntryIdSetting(entryId: Int?) {
         dataStore.edit { preferences ->
-            preferences[LEAGUES_SETTING] = leagues.joinToString(separator = ",")
+            if (entryId == null) {
+                preferences.remove(ENTRY_ID_SETTING)
+            } else {
+                preferences[ENTRY_ID_SETTING] = entryId.toString()
+            }
         }
     }
 
-
-    private fun getLeaguesSettingFromString(settingsString: String?) =
-        settingsString?.split(",") ?: emptyList()
-
     companion object {
-        val LEAGUES_SETTING = stringPreferencesKey("leagues")
+        val ENTRY_ID_SETTING = stringPreferencesKey("entryId")
     }
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueTool.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/agent/FantasyPremierLeagueTool.kt
@@ -56,21 +56,30 @@ class GetFixturesTool(val fantasyPremierLeagueRepository: FantasyPremierLeagueRe
 class GetLeagueStandingsTool(val fantasyPremierLeagueRepository: FantasyPremierLeagueRepository) : SimpleTool<Unit>(
     argsType = typeToken<Unit>(),
     name = "getLeagueStandings",
-    description = "Get the standings for the user's tracked mini-leagues"
+    description = "Get the user's own mini-league standings, discovered from the team id they have set"
 ) {
     override suspend fun execute(args: Unit): String {
         try {
-            val leagueIds = fantasyPremierLeagueRepository.leagues.first()
-            if (leagueIds.isEmpty()) {
-                return "The user is not tracking any mini-leagues."
+            val entryId = fantasyPremierLeagueRepository.entryId.first()
+                ?: return "The user has not set their FPL team id, so their leagues aren't known."
+
+            val manager = fantasyPremierLeagueRepository.getManager(entryId)
+                ?: return "No FPL team found with id $entryId."
+            // Invitational leagues only - the automatically-joined ones run to millions of entries,
+            // where the top 50 strangers tell the user nothing.
+            val leagues = manager.leagues.filter { it.isInvitational }
+            if (leagues.isEmpty()) {
+                return "${manager.teamName} is not in any mini-leagues."
             }
-            return leagueIds.mapNotNull { leagueId ->
+
+            return leagues.mapNotNull { league ->
                 runCatching {
-                    val standings = fantasyPremierLeagueRepository.getLeagueStandings(leagueId.trim().toInt())
+                    val standings = fantasyPremierLeagueRepository.getLeagueStandings(league.id)
                     val rows = standings.standings.results.joinToString("\n") { result ->
                         "${result.rank}. ${result.entryName} (${result.playerName}) - ${result.total} pts"
                     }
-                    "League '${standings.league.name}':\n$rows"
+                    "League '${league.name}' (${manager.teamName} is ${league.entryRank ?: "unranked"} " +
+                        "of ${league.entryCount ?: "?"}):\n$rows"
                 }.getOrNull()
             }.joinToString("\n\n").ifEmpty { "No league standings available." }
         } catch (e: Exception) {

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/EntryDto.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/EntryDto.kt
@@ -1,0 +1,43 @@
+package dev.johnoreilly.common.data.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A manager's own record, from `entry/{entryId}/`. Public - no session needed - but keyed on the
+ * entry id, which a manager reads off their own FPL url. There is no way to look one up by name.
+ */
+@Serializable
+data class EntryDto(
+    val id: Int,
+    val name: String,
+    val player_first_name: String = "",
+    val player_last_name: String = "",
+    val summary_overall_points: Int? = null,
+    val summary_overall_rank: Int? = null,
+    // Both in tenths of a million, as with player prices.
+    val last_deadline_bank: Int? = null,
+    val last_deadline_value: Int? = null,
+    val leagues: EntryLeaguesDto = EntryLeaguesDto()
+)
+
+/** `cup` is an object rather than a list of leagues, so only the two league lists are modelled. */
+@Serializable
+data class EntryLeaguesDto(
+    val classic: List<EntryLeagueDto> = emptyList(),
+    val h2h: List<EntryLeagueDto> = emptyList()
+)
+
+@Serializable
+data class EntryLeagueDto(
+    val id: Int,
+    val name: String,
+    val short_name: String? = null,
+    val entry_rank: Int? = null,
+    val entry_last_rank: Int? = null,
+    val rank_count: Int? = null,
+    // "x" = invitational (a league someone created and invited you to), "s" = joined automatically
+    // on signup - your club, your country, your starting gameweek, and Overall.
+    val league_type: String = "x",
+    val scoring: String = "c",
+    val start_event: Int = 1
+)

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/LeagueResultDto.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/model/LeagueResultDto.kt
@@ -5,15 +5,19 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LeagueResultDto(
-    val id: Int,
-    val rank: Int,
+    // The manager's entry id. FPL used to send this as "id"; requiring that name made every
+    // standings request fail to parse once they renamed it, which left the leagues screen blank.
+    // Everything here is defaulted so a future rename degrades a column rather than the screen.
+    @SerialName("entry")
+    val entryId: Int? = null,
+    val rank: Int = 0,
     @SerialName("last_rank")
-    val lastRank: Int,
+    val lastRank: Int = 0,
     @SerialName("event_total")
-    val eventTotal: Int,
-    val total: Int,
+    val eventTotal: Int = 0,
+    val total: Int = 0,
     @SerialName("player_name")
-    val playerName: String,
+    val playerName: String = "",
     @SerialName("entry_name")
-    val entryName: String
+    val entryName: String = ""
 )

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/remote/FantasyPremierLeagueApi.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/remote/FantasyPremierLeagueApi.kt
@@ -2,6 +2,7 @@ package dev.johnoreilly.common.data.remote
 
 import dev.johnoreilly.common.data.model.BootstrapStaticInfoDto
 import dev.johnoreilly.common.data.model.ElementSummaryDto
+import dev.johnoreilly.common.data.model.EntryDto
 import dev.johnoreilly.common.data.model.EventStatusListDto
 import dev.johnoreilly.common.data.model.FixtureDto
 import dev.johnoreilly.common.data.model.GameWeekLiveDataDto
@@ -10,6 +11,7 @@ import dev.johnoreilly.common.data.model.RegionDto
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.http.*
 import org.koin.core.component.KoinComponent
 
 
@@ -22,12 +24,23 @@ class FantasyPremierLeagueApi(
         return client.get("$baseUrl/$endpoint").body()
     }
 
+    /**
+     * As [fetchData], but treats 404 as "no such thing" rather than an error. FPL answers an
+     * unknown id with a 404 carrying {"detail": "..."}, which would otherwise fail deserialization
+     * with a confusing missing-fields message.
+     */
+    private suspend inline fun <reified T> fetchDataOrNull(endpoint: String): T? {
+        val response = client.get("$baseUrl/$endpoint")
+        return if (response.status == HttpStatusCode.NotFound) null else response.body()
+    }
+
     suspend fun fetchBootstrapStaticInfo() = fetchData<BootstrapStaticInfoDto>("bootstrap-static/")
     suspend fun fetchRegions() = fetchData<List<RegionDto>>("regions/")
     suspend fun fetchFixtures() = fetchData<List<FixtureDto>>("fixtures")
     suspend fun fetchUpcomingFixtures() = fetchData<List<FixtureDto>>("fixtures?future=1")
     suspend fun fetchGameWeekLiveData(eventId: Int) = fetchData<GameWeekLiveDataDto>("event/$eventId/live/")
     suspend fun fetchPlayerData(playerId: Int) = fetchData<ElementSummaryDto>("element-summary/$playerId/")
+    suspend fun fetchEntry(entryId: Int) = fetchDataOrNull<EntryDto>("entry/$entryId/")
     suspend fun fetchLeagueStandings(leagueId: Int) = fetchData<LeagueStandingsDto>("leagues-classic/$leagueId/standings/")
     suspend fun fetchEventStatus() = fetchData<EventStatusListDto>("event-status/")
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/data/repository/FantasyPremierLeagueRepository.kt
@@ -2,6 +2,8 @@ package dev.johnoreilly.common.data.repository
 
 import dev.johnoreilly.common.AppSettings
 import dev.johnoreilly.common.data.model.BootstrapStaticInfoDto
+import dev.johnoreilly.common.data.model.EntryDto
+import dev.johnoreilly.common.data.model.EntryLeagueDto
 import dev.johnoreilly.common.data.model.EventStatusListDto
 import dev.johnoreilly.common.data.model.FixtureDto
 import dev.johnoreilly.common.data.model.GameSettingsDto
@@ -11,6 +13,8 @@ import dev.johnoreilly.common.database.AppDatabase
 import dev.johnoreilly.common.model.GameFixture
 import dev.johnoreilly.common.model.GameRules
 import dev.johnoreilly.common.model.Gameweek
+import dev.johnoreilly.common.model.League
+import dev.johnoreilly.common.model.Manager
 import dev.johnoreilly.common.model.PlayerPastHistory
 import dev.johnoreilly.common.model.Player
 import dev.johnoreilly.common.model.PositionRule
@@ -37,7 +41,7 @@ class FantasyPremierLeagueRepository : KoinComponent {
 
     val coroutineScope = CoroutineScope(Dispatchers.Default)
 
-    val leagues = appSettings.leagues
+    val entryId = appSettings.entryId
 
     private var _currentGameweek: MutableStateFlow<Int> = MutableStateFlow(1)
     val currentGameweek = _currentGameweek.asStateFlow()
@@ -256,7 +260,38 @@ class FantasyPremierLeagueRepository : KoinComponent {
         return fantasyPremierLeagueApi.fetchEventStatus()
     }
 
-    suspend fun updateLeagues(leagues: List<String>) {
-        appSettings.updatesLeaguesSetting(leagues)
+    suspend fun updateEntryId(entryId: Int?) {
+        appSettings.updateEntryIdSetting(entryId)
+    }
+
+    /**
+     * The manager and every league they're in, from one call. Rank and league size come back on
+     * this response, so a league list needs no per-league standings fetch.
+     *
+     * Null when no team has that id.
+     */
+    suspend fun getManager(entryId: Int): Manager? {
+        val entry = fantasyPremierLeagueApi.fetchEntry(entryId) ?: return null
+        fun EntryLeagueDto.toLeague(headToHead: Boolean) = League(
+            id = id,
+            name = name,
+            entryRank = entry_rank,
+            lastRank = entry_last_rank,
+            entryCount = rank_count,
+            isInvitational = league_type == "x",
+            isHeadToHead = headToHead
+        )
+        return Manager(
+            id = entry.id,
+            teamName = entry.name,
+            playerName = "${entry.player_first_name} ${entry.player_last_name}".trim(),
+            overallPoints = entry.summary_overall_points,
+            overallRank = entry.summary_overall_rank,
+            // Tenths of a million on the wire, as with player prices.
+            bank = entry.last_deadline_bank?.let { it / 10.0 },
+            teamValue = entry.last_deadline_value?.let { it / 10.0 },
+            leagues = entry.leagues.classic.map { it.toLeague(headToHead = false) } +
+                entry.leagues.h2h.map { it.toLeague(headToHead = true) }
+        )
     }
 }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/model/Manager.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/model/Manager.kt
@@ -1,0 +1,26 @@
+package dev.johnoreilly.common.model
+
+/** A manager and the leagues they're in, as returned in a single `entry/{id}/` call. */
+data class Manager(
+    val id: Int,
+    val teamName: String,
+    val playerName: String,
+    val overallPoints: Int?,
+    val overallRank: Int?,
+    val bank: Double?,
+    val teamValue: Double?,
+    val leagues: List<League>
+)
+
+data class League(
+    val id: Int,
+    val name: String,
+    /** This manager's current rank in the league, and their rank last gameweek. */
+    val entryRank: Int?,
+    val lastRank: Int?,
+    /** How many managers are in the league. */
+    val entryCount: Int?,
+    /** A league someone created and invited people to, as opposed to one joined automatically. */
+    val isInvitational: Boolean,
+    val isHeadToHead: Boolean
+)

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/leagues/LeagueListView.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/leagues/LeagueListView.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import dev.johnoreilly.common.model.League
 import dev.johnoreilly.common.viewmodel.LeaguesViewModel
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -35,6 +36,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun LeagueListView() {
     val viewModel = koinViewModel<LeaguesViewModel>()
     val leagueStandings by viewModel.leagueStandings.collectAsStateWithLifecycle(emptyList())
+    val entryId by viewModel.entryId.collectAsStateWithLifecycle(null)
 
     Scaffold(
         topBar = {
@@ -42,13 +44,21 @@ fun LeagueListView() {
         }) {
 
         Box(Modifier.padding(it)) {
-            LazyColumn(Modifier.fillMaxSize()) {
-                leagueStandings.forEach { league ->
-                    stickyHeader {
-                        Header(text = league.league.name)
-                    }
-                    items(items = league.standings.results) { leagueResult ->
-                        LeagueResultView(leagueResult = leagueResult)
+            if (entryId == null) {
+                Text(
+                    text = "Set your team id in Settings to see your leagues.",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                LazyColumn(Modifier.fillMaxSize()) {
+                    leagueStandings.forEach { (league, standings) ->
+                        stickyHeader {
+                            Header(text = league.name, subtitle = league.rankSummary())
+                        }
+                        items(items = standings.standings.results) { leagueResult ->
+                            LeagueResultView(leagueResult = leagueResult)
+                        }
                     }
                 }
             }
@@ -56,11 +66,30 @@ fun LeagueListView() {
     }
 }
 
+/** "3rd of 47" - both numbers come back on the entry call, so this costs no extra request. */
+private fun League.rankSummary(): String? {
+    val rank = entryRank ?: return null
+    val total = entryCount ?: return "${rank.ordinal()}"
+    return "${rank.ordinal()} of $total"
+}
+
+private fun Int.ordinal(): String {
+    val suffix = when {
+        this % 100 in 11..13 -> "th"
+        this % 10 == 1 -> "st"
+        this % 10 == 2 -> "nd"
+        this % 10 == 3 -> "rd"
+        else -> "th"
+    }
+    return "$this$suffix"
+}
+
 
 @Composable
 internal fun Header(
     modifier: Modifier = Modifier,
     text: String,
+    subtitle: String? = null,
     icon: ImageVector? = null
 ) {
     Surface(
@@ -86,11 +115,20 @@ internal fun Header(
                         contentDescription = null,
                     )
                 }
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                )
+                Column {
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    subtitle?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                }
             }
             HorizontalDivider()
         }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/settings/SettingsView.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/settings/SettingsView.kt
@@ -3,6 +3,7 @@
 package dev.johnoreilly.common.ui.settings
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -19,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import dev.johnoreilly.common.viewmodel.LeaguesViewModel
 import org.koin.compose.viewmodel.koinViewModel
@@ -27,8 +29,8 @@ import org.koin.compose.viewmodel.koinViewModel
 fun SettingsView(popBackStack: () -> Unit) {
     val viewModel = koinViewModel<LeaguesViewModel>()
 
-    val leagueIdsString = remember {
-        mutableStateOf(viewModel.leagues.value.joinToString())
+    val entryIdString = remember {
+        mutableStateOf(viewModel.entryId.value?.toString().orEmpty())
     }
 
     Scaffold(
@@ -50,14 +52,21 @@ fun SettingsView(popBackStack: () -> Unit) {
 
             TextField(
                 modifier = Modifier.fillMaxWidth(),
-                value = leagueIdsString.value,
-                onValueChange = { leagueIds ->
-                    leagueIdsString.value = leagueIds
-                })
+                value = entryIdString.value,
+                onValueChange = { entryId ->
+                    entryIdString.value = entryId.filter { it.isDigit() }
+                },
+                singleLine = true,
+                label = { Text("Your team id") },
+                supportingText = {
+                    Text("The number in your FPL url: fantasy.premierleague.com/entry/1234567/…")
+                },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+            )
             Button(onClick = {
-                viewModel.updateLeagues(leagueIdsString.value.split(", "))
+                viewModel.updateEntryId(entryIdString.value.toIntOrNull())
             }) {
-                Text("Set Leagues")
+                Text("Set Team")
             }
         }
     }

--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/LeaguesViewModel.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/viewmodel/LeaguesViewModel.kt
@@ -3,34 +3,66 @@ package dev.johnoreilly.common.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dev.johnoreilly.common.data.model.EventStatusDto
+import dev.johnoreilly.common.data.model.LeagueStandingsDto
 import dev.johnoreilly.common.data.repository.FantasyPremierLeagueRepository
-import kotlinx.coroutines.flow.MutableStateFlow
+import dev.johnoreilly.common.model.League
+import dev.johnoreilly.common.model.Manager
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
+
+/** A league the manager is in, paired with its current table. */
+data class LeagueWithStandings(
+    val league: League,
+    val standings: LeagueStandingsDto
+)
 
 open class LeaguesViewModel(
     private val repository: FantasyPremierLeagueRepository
 ) : ViewModel(), KoinComponent {
-    val leagues: StateFlow<List<String>> = repository.leagues
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    val entryId: StateFlow<Int?> = repository.entryId
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
 
-    var leagueStandings = repository.leagues.map { leagues ->
-        leagues.map { leagueId ->
-            repository.getLeagueStandings(leagueId.trim().toInt())
+    val manager: StateFlow<Manager?> = repository.entryId
+        .map { id -> id?.let { runCatching { repository.getManager(it) }.getOrNull() } }
+        .stateIn(viewModelScope, SharingStarted.Lazily, null)
+
+    /**
+     * Tables for the manager's invitational leagues only. The automatically-joined ones (Overall,
+     * their country, their club) run to millions of entries, where a table of the top 50 strangers
+     * says nothing useful - those are still listed, just not fetched.
+     *
+     * Fetched concurrently: a manager in a dozen leagues would otherwise wait on a dozen
+     * round trips one after another.
+     */
+    val leagueStandings: StateFlow<List<LeagueWithStandings>> = manager
+        .map { manager ->
+            val leagues = manager?.leagues.orEmpty().filter { it.isInvitational }
+            coroutineScope {
+                leagues
+                    .map { league ->
+                        async {
+                            runCatching { repository.getLeagueStandings(league.id) }
+                                .getOrNull()
+                                ?.let { LeagueWithStandings(league, it) }
+                        }
+                    }
+                    .awaitAll()
+                    .filterNotNull()
+            }
         }
-    }.stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
+        .stateIn(viewModelScope, SharingStarted.Lazily, emptyList())
 
-    private val _isRefreshing = MutableStateFlow(false)
-
-    fun updateLeagues(leagues: List<String>) {
+    fun updateEntryId(entryId: Int?) {
         viewModelScope.launch {
-            repository.updateLeagues(leagues)
+            repository.updateEntryId(entryId)
         }
     }
 

--- a/mcp-server/src/main/kotlin/server.kt
+++ b/mcp-server/src/main/kotlin/server.kt
@@ -220,6 +220,60 @@ fun configureServer(): Server {
     }
 
     server.addTool(
+        name = "get-manager-leagues",
+        description = "Every league a manager is in - mini-leagues they were invited to plus the " +
+            "ones joined automatically (Overall, their country, their club) - with their rank in " +
+            "each. Also returns their squad value, money in the bank and overall points. Needs the " +
+            "manager's team id, the number in their FPL url: fantasy.premierleague.com/entry/1234567/",
+        inputSchema = optionalIntSchema(
+            "entryId",
+            "The manager's team (entry) id. Omit to use the team id saved in the app's settings."
+        )
+    ) { request ->
+        repository.awaitInitialLoad()
+        val entryId = intArg(request, "entryId") ?: repository.entryId.first()
+        if (entryId == null) {
+            return@addTool text(
+                "No team id given, and none saved in the app's settings. Ask the user for the " +
+                    "number in their FPL url, e.g. fantasy.premierleague.com/entry/1234567/"
+            )
+        }
+
+        val manager = runCatching { repository.getManager(entryId) }.getOrElse { error ->
+            return@addTool text("Could not load team $entryId: ${error.message}")
+        } ?: return@addTool text(
+            "No FPL team has id $entryId. The team id is the number in the manager's FPL url, " +
+                "e.g. fantasy.premierleague.com/entry/1234567/"
+        )
+
+        val rows = manager.leagues.map { league ->
+            listOf(
+                league.id.toString(),
+                csvSafe(league.name),
+                league.entryRank?.toString() ?: "",
+                league.entryCount?.toString() ?: "",
+                league.lastRank?.toString() ?: "",
+                if (league.isInvitational) "mini" else "auto",
+                if (league.isHeadToHead) "h2h" else "classic"
+            ).joinToString(",")
+        }
+
+        text(
+            (listOf(
+                "${manager.teamName} (${manager.playerName}), team id ${manager.id}.",
+                "Overall: ${manager.overallPoints ?: "?"} points, rank ${manager.overallRank ?: "?"}.",
+                "Squad value £${manager.teamValue?.toFixed(1) ?: "?"}m, £${manager.bank?.toFixed(1) ?: "?"}m in the bank.",
+                "",
+                "${manager.leagues.size} leagues. kind: mini = invited by someone, auto = joined on " +
+                    "signup (Overall, country, club, starting gameweek).",
+                "rank is this manager's position; n is how many managers are in the league.",
+                "",
+                "id,name,rank,n,lastRank,kind,type"
+            ) + rows).joinToString("\n")
+        )
+    }
+
+    server.addTool(
         name = "get-fixtures",
         description = "Full fixture list for the season, including results for matches already played"
     ) {


### PR DESCRIPTION
## Summary

Settings asked for a comma-separated list of **league** ids, so you had to hunt each one down and type it. `entry/{entryId}/` already knows every league a manager is in, so this asks for one number — the id in their own FPL url — and reads the leagues from it. The endpoint is public; no login needed (verified with a bare `curl`: HTTP 200).

Rank and league size come back on that same response, so league headers show "1st of 1173" with **no request per league**. Standings are still fetched, but only for invitational leagues — the automatically-joined ones (Overall, your country, your club) run to millions of entries, where a table of the top 50 strangers says nothing — and those fetches now run concurrently rather than one after another.

Adds a **`get-manager-leagues` MCP tool** taking a team id, or falling back to the saved one, and points the agent's `getLeagueStandings` at the same discovery. `fetchEntry` treats 404 as "no such team" rather than letting the error body fail deserialization, so a mistyped id reports itself plainly instead of leaking a missing-fields error.

### Also fixes a pre-existing bug (separate commit)

The Leagues tab has been rendering **blank for everyone**, independent of this work. `LeagueResultDto` required an `id` field FPL no longer sends — the manager's entry id now arrives as `entry`. Every standings request failed deserialization, and the caller's `runCatching` swallowed it, so there was no clue why. The remaining fields are now defaulted, so the next rename costs a column rather than the screen.

## Test plan

- [x] `entry/{id}/` verified against the live API with a real manager (16 leagues returned)
- [x] MCP tool exercised over stdio: valid id, omitted id (falls back / prompts), unknown id (clean "no such team")
- [x] On device: entered team id in Settings → Leagues tab populated with real standings and "1st of 1173" headers, no crashes
- [x] `:common` compiles for JVM, Android, iosArm64, iosSimulatorArm64; `:app:assembleDebug`, `:compose-desktop`, `:mcp-server:shadowJar`
- [x] 10/10 tests pass
- [x] Re-verified after merging latest main (setup-java v6, slf4j 2.0.19)

⚠️ **Migration:** `AppSettings` swaps the `leagues` key for `entryId`, so anyone with saved league ids silently loses them and sees an empty Leagues tab until they enter a team id. Fine for a sample app — happy to read the old key once and keep both working if you'd rather.

Worth noting the same `entry/{id}/` response carries `last_deadline_bank`, `last_deadline_value` and `summary_overall_rank`. Paired with `entry/{id}/event/{gw}/picks/` that's the missing piece for advising on transfers from a real squad rather than building one from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gQFnBGPvUS7UoS4gdEHqn