### PR TITLE
Migrate the season chart to koalaplot 0.12

### DIFF
--- a/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/players/playerDetails/PlayerDetailsViewShared.kt
+++ b/common/src/commonMain/kotlin/dev/johnoreilly/common/ui/players/playerDetails/PlayerDetailsViewShared.kt
@@ -2,6 +2,9 @@ package dev.johnoreilly.common.ui.players.playerDetails
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.hoverable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,7 +29,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -36,7 +39,7 @@ import dev.johnoreilly.common.ui.global.rememberPlayerPhotoPainter
 import fantasypremierleague.common.generated.resources.Res
 import fantasypremierleague.common.generated.resources.team
 import io.github.koalaplot.core.ChartLayout
-import io.github.koalaplot.core.bar.DefaultBar
+import io.github.koalaplot.core.bar.BarScope
 import io.github.koalaplot.core.bar.VerticalBarPlot
 import io.github.koalaplot.core.bar.VerticalBarPlotEntry
 import io.github.koalaplot.core.bar.verticalBarPlotEntry
@@ -47,7 +50,9 @@ import io.github.koalaplot.core.xygraph.CategoryAxisModel
 import io.github.koalaplot.core.xygraph.IntLinearAxisModel
 import io.github.koalaplot.core.xygraph.TickPosition
 import io.github.koalaplot.core.xygraph.XYGraph
+import io.github.koalaplot.core.xygraph.rememberAxisContent
 import io.github.koalaplot.core.xygraph.rememberAxisStyle
+import io.github.koalaplot.core.xygraph.rememberGridStyle
 import org.jetbrains.compose.resources.stringResource
 
 
@@ -180,6 +185,30 @@ fun AxisLabel(label: String, modifier: Modifier = Modifier) {
     )
 }
 
+/**
+ * A single season's bar, showing its points total on hover.
+ *
+ * koalaplot 0.12 dropped DefaultBar's hoverElement slot along with the hoverableElement modifier
+ * behind it, so the tooltip is wired up here with ordinary Compose hover state. Only desktop and
+ * web can hover, so touch simply gets the bar.
+ */
+@Composable
+private fun BarScope.SeasonBar(points: Int, color: Color) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isHovered by interactionSource.collectIsHoveredAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .hoverable(interactionSource)
+            .background(color)
+    ) {
+        if (isHovered) {
+            HoverSurface(Modifier.align(Alignment.TopCenter)) { Text(points.toString()) }
+        }
+    }
+}
+
 @Composable
 fun HoverSurface(modifier: Modifier = Modifier, content: @Composable () -> Unit) {
     Surface(
@@ -223,36 +252,34 @@ private fun PlayerHistoryBarPlot(
                 minimumMajorTickIncrement = 1,
                 minorTickCount = 0
             ),
-            xAxisStyle = rememberAxisStyle(
-                tickPosition = tickPositionState.horizontalAxis,
-                color = MaterialTheme.colorScheme.surfaceVariant
-            ),
-            xAxisLabels = {
-                AxisLabel(it, Modifier.padding(top = 2.dp))
-            },
-            xAxisTitle = { AxisTitle("Season") },
-            yAxisStyle = rememberAxisStyle(tickPosition = tickPositionState.verticalAxis),
-            yAxisLabels = {
-                AxisLabel(it.toString(), Modifier.absolutePadding(right = 2.dp))
-            },
-            yAxisTitle = {
-                AxisTitle(
-                    "Points",
-                    modifier = Modifier.rotateVertically(VerticalRotation.COUNTER_CLOCKWISE)
-                        .padding(bottom = 8.dp)
+            xAxisContent = rememberAxisContent(
+                labels = { AxisLabel(it, Modifier.padding(top = 2.dp)) },
+                title = { AxisTitle("Season") },
+                style = rememberAxisStyle(
+                    tickPosition = tickPositionState.horizontalAxis,
+                    color = MaterialTheme.colorScheme.surfaceVariant
                 )
-            },
-            verticalMajorGridLineStyle = null
+            ),
+            yAxisContent = rememberAxisContent(
+                labels = { AxisLabel(it.toString(), Modifier.absolutePadding(right = 2.dp)) },
+                title = {
+                    AxisTitle(
+                        "Points",
+                        modifier = Modifier.rotateVertically(VerticalRotation.COUNTER_CLOCKWISE)
+                            .padding(bottom = 8.dp)
+                    )
+                },
+                style = rememberAxisStyle(tickPosition = tickPositionState.verticalAxis)
+            ),
+            gridStyle = rememberGridStyle(verticalMajorStyle = null)
         ) {
             VerticalBarPlot(
                 barChartEntries,
                 bar = { _, _, value ->
-                    DefaultBar(
-                        brush = SolidColor(MaterialTheme.colorScheme.primary),
-                        modifier = Modifier.fillMaxWidth(),
-                    ) {
-                        HoverSurface { Text(value.y.end.toString()) }
-                    }
+                    SeasonBar(
+                        points = value.y.end,
+                        color = MaterialTheme.colorScheme.primary
+                    )
                 }
             )
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlinx-serialization = "1.11.0"
 kotlinx-dateTime = "0.8.0-0.6.x-compat"
 
 androidGradlePlugin = "9.1.1"
-koalaplot = "0.11.2"
+koalaplot = "0.12.1"
 koin = "4.2.2"
 ktor = "3.5.2"
 slf4j = "2.0.19"


### PR DESCRIPTION
## Summary

Supersedes #359, which has been red for 10 months. That bump can't land on its own — 0.12 is a breaking API change, not a version number.

**What broke.** `XYGraph` replaced its flat axis parameters (`xAxisStyle`, `xAxisLabels`, `xAxisTitle`, and the y equivalents) with `AxisContent` objects, and folded the gridline styles into `GridStyle`. CI on #359 showed `No parameter with name 'xAxisStyle' found` and half a dozen like it. The app's own `AxisLabel`, `AxisTitle` and `ChartTitle` live in the same file and are unaffected.

**The tooltip.** 0.12 also dropped `DefaultBar`'s `hoverElement` slot along with the `Modifier.hoverableElement` behind it, which is what showed a bar's points on hover. The trailing lambda was binding to the new `border: BorderStroke?` parameter — hence `Argument type mismatch: actual '() -> Unit', but 'BorderStroke?' expected`. Rather than silently lose the feature, the bar is now emitted directly with ordinary Compose hover state (`hoverable` + `collectIsHoveredAsState`), reusing the app's existing `HoverSurface`.

The chart was already compiling against a deprecated `XYGraph` overload, so this clears that warning too.

## Test plan

- [x] `:common` compiles for JVM, Android, iosArm64, iosSimulatorArm64
- [x] `:app:assembleDebug`, `:compose-desktop:compileKotlin`, `:mcp-server:shadowJar`
- [x] 11/11 tests pass (`:common:jvmTest` + `:app:testDebugUnitTest`)
- [x] koalaplot deprecation warning gone; remaining warnings are unrelated and pre-existing
- [x] Chart verified rendering on device — bars, both axis titles and labels, chart title, and vertical major gridlines still suppressed, matching the previous appearance
- [ ] The hover tooltip is desktop/web only and was verified by compilation, not visually — worth a look if you run the desktop app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gQFnBGPvUS7UoS4gdEHqn